### PR TITLE
Fix function-verification findings: hardware keyboard, host-key prompt, display link, accessory keys, sticky mods

### DIFF
--- a/Sources/Ghostty/AccessoryKeyboardView.swift
+++ b/Sources/Ghostty/AccessoryKeyboardView.swift
@@ -8,8 +8,13 @@ final class AccessoryKeyboardView: UIInputView {
     private weak var target: TerminalSurfaceView?
     private var ctrlButton: UIButton?
     private var altButton: UIButton?
+    private var fnButton: UIButton?
+    private var functionKeys: [UIButton] = []
+    private var fnVisible = false
 
     private static let barHeight: CGFloat = 48
+    private static let functionKeyList: [Ghostty.Key] =
+        [.f1, .f2, .f3, .f4, .f5, .f6, .f7, .f8, .f9, .f10, .f11, .f12]
 
     init(target: TerminalSurfaceView) {
         self.target = target
@@ -73,6 +78,13 @@ final class AccessoryKeyboardView: UIInputView {
         stack.addArrangedSubview(alt)
 
         stack.addArrangedSubview(specialButton("tab") { $0.pressSpecial(.tab) })
+
+        // Fn toggles a function-key row (F1–F12) in/out of view.
+        let fn = makeButton("fn")
+        fn.addAction(UIAction { [weak self] _ in self?.toggleFunctionKeys() }, for: .touchUpInside)
+        fnButton = fn
+        stack.addArrangedSubview(fn)
+
         stack.addArrangedSubview(specialButton("◀") { $0.pressSpecial(.left) })
         stack.addArrangedSubview(specialButton("▲") { $0.pressSpecial(.up) })
         stack.addArrangedSubview(specialButton("▼") { $0.pressSpecial(.down) })
@@ -83,10 +95,26 @@ final class AccessoryKeyboardView: UIInputView {
             stack.addArrangedSubview(specialButton(sym) { $0.insertSymbol(sym) })
         }
 
+        stack.addArrangedSubview(specialButton("del") { $0.pressSpecial(.delete) })
         stack.addArrangedSubview(specialButton("home") { $0.pressSpecial(.home) })
         stack.addArrangedSubview(specialButton("end") { $0.pressSpecial(.end) })
         stack.addArrangedSubview(specialButton("pgup") { $0.pressSpecial(.pageUp) })
         stack.addArrangedSubview(specialButton("pgdn") { $0.pressSpecial(.pageDown) })
+
+        // Function keys (hidden until Fn is tapped).
+        for (i, key) in Self.functionKeyList.enumerated() {
+            let button = specialButton("F\(i + 1)") { $0.pressSpecial(key) }
+            button.isHidden = true
+            functionKeys.append(button)
+            stack.addArrangedSubview(button)
+        }
+    }
+
+    /// Show/hide the F1–F12 row.
+    private func toggleFunctionKeys() {
+        fnVisible.toggle()
+        setArmed(fnButton, fnVisible)
+        for button in functionKeys { button.isHidden = !fnVisible }
     }
 
     /// Reset the visual armed state of the modifier keys.

--- a/Sources/Ghostty/GhosttyApp.swift
+++ b/Sources/Ghostty/GhosttyApp.swift
@@ -11,6 +11,7 @@ extension Ghostty {
     final class App: ObservableObject {
         let config: Config
         private(set) var app: ghostty_app_t?
+        private var displayLink: CADisplayLink?
 
         init() {
             // ghostty_init must be called exactly once before ghostty_app_new.
@@ -41,15 +42,33 @@ extension Ghostty {
             }
             self.app = app
             ghostty_app_set_focus(app, true)
+            startDisplayLink()
         }
 
         deinit {
+            displayLink?.invalidate()
             if let app { ghostty_app_free(app) }
         }
 
         func tick() {
             guard let app else { return }
             ghostty_app_tick(app)
+        }
+
+        /// Drive `ghostty_app_tick` once per display refresh so animations
+        /// (cursor blink, etc.) advance smoothly, in addition to the on-demand
+        /// wakeup callback. A weak proxy avoids the CADisplayLink→target retain
+        /// cycle so the app can still be torn down.
+        private func startDisplayLink() {
+            let link = CADisplayLink(target: DisplayLinkProxy(self), selector: #selector(DisplayLinkProxy.step))
+            link.add(to: .main, forMode: .common)
+            displayLink = link
+        }
+
+        private final class DisplayLinkProxy {
+            weak var app: App?
+            init(_ app: App) { self.app = app }
+            @objc func step() { app?.tick() }
         }
 
         func setColorScheme(_ scheme: ghostty_color_scheme_e) {

--- a/Sources/Ghostty/GhosttyInput.swift
+++ b/Sources/Ghostty/GhosttyInput.swift
@@ -121,6 +121,41 @@ extension Ghostty {
             }
         }
 
+        /// Map a printable character to its physical key *plus* whether Shift is
+        /// needed to produce it on a US layout. This lets modifier combos with
+        /// shifted symbols (Ctrl-_, Alt-|, Ctrl-^) be encoded as real key
+        /// events, where `init?(character:)` alone would drop the Shift.
+        static func physical(for character: Character) -> (key: Key, shift: Bool)? {
+            if let base = Key(character: character) { return (base, false) }
+            switch character {
+            case "|": return (.backslash, true);    case "~": return (.backquote, true)
+            case ":": return (.semicolon, true);    case "_": return (.minus, true)
+            case "!": return (.d1, true);           case "@": return (.d2, true)
+            case "#": return (.d3, true);           case "$": return (.d4, true)
+            case "%": return (.d5, true);           case "^": return (.d6, true)
+            case "&": return (.d7, true);           case "*": return (.d8, true)
+            case "(": return (.d9, true);           case ")": return (.d0, true)
+            case "{": return (.bracketLeft, true);  case "}": return (.bracketRight, true)
+            case "+": return (.equal, true);        case "\"": return (.quote, true)
+            case "<": return (.comma, true);        case ">": return (.period, true)
+            case "?": return (.slash, true)
+            default: return nil
+            }
+        }
+
+        /// True for keys that must be sent as key events (not text) because the
+        /// terminal encodes them mode-dependently (arrows, function keys, etc.).
+        var isSpecial: Bool {
+            switch self {
+            case .escape, .tab, .enter, .backspace, .delete,
+                 .up, .down, .left, .right, .home, .end, .pageUp, .pageDown, .insert,
+                 .f1, .f2, .f3, .f4, .f5, .f6, .f7, .f8, .f9, .f10, .f11, .f12:
+                return true
+            default:
+                return false
+            }
+        }
+
         var cKey: ghostty_input_key_e {
             switch self {
             case .a: return GHOSTTY_KEY_A; case .b: return GHOSTTY_KEY_B

--- a/Sources/Ghostty/TerminalSurfaceView+Hardware.swift
+++ b/Sources/Ghostty/TerminalSurfaceView+Hardware.swift
@@ -1,0 +1,119 @@
+import UIKit
+import GhosttyKit
+
+/// Hardware (physical) keyboard support: Bluetooth / Smart Keyboard / Magic
+/// Keyboard. iOS delivers physical key presses as `UIPress`/`UIKey` events
+/// through the responder chain (gated by `UIApplicationSupportsIndirectInputEvents`).
+///
+/// Routing mirrors the soft-keyboard path: special keys (arrows, esc, function
+/// keys, …) and any Ctrl/Alt/Cmd combos are sent through `ghostty_surface_key`
+/// (mode-aware), while plain printable input is left to `UIKeyInput.insertText`
+/// so the layout-correct character is produced and we never double-send.
+extension TerminalSurfaceView {
+    override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        let unhandled = presses.filter { !handleHardwarePress($0, action: .press) }
+        if !unhandled.isEmpty { super.pressesBegan(unhandled, with: event) }
+    }
+
+    override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        super.pressesEnded(presses, with: event)
+    }
+
+    override func pressesCancelled(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        super.pressesCancelled(presses, with: event)
+    }
+
+    /// Returns true if we consumed the press (sent it as a key event), false to
+    /// let UIKit's text path handle it.
+    private func handleHardwarePress(_ press: UIPress, action: Ghostty.KeyAction) -> Bool {
+        guard let uiKey = press.key else { return false }
+
+        var mods = Ghostty.Mods.fromHardware(uiKey.modifierFlags)
+        mods.formUnion(stickyMods)
+
+        guard let key = Ghostty.Key(hid: uiKey.keyCode) else {
+            // Unknown physical key but a modifier is armed from the accessory
+            // bar — fall through to text so the modifier doesn't get stuck.
+            if !stickyMods.isEmpty { clearStickyMods() }
+            return false
+        }
+
+        // Shift alone is "just a capital/shifted character" — that belongs to
+        // the text path. Anything beyond Shift (Ctrl/Alt/Cmd), or a special
+        // key, must go through the key encoder.
+        let beyondShift = !mods.subtracting(.shift).isEmpty
+        if key.isSpecial || beyondShift {
+            sendKey(key, mods: mods, action: action)
+            clearStickyMods()
+            return true
+        }
+
+        // Plain printable key. If a sticky modifier was armed (accessory bar),
+        // honor it as a key event; otherwise defer to insertText.
+        if !stickyMods.isEmpty {
+            sendKey(key, mods: mods, action: action)
+            clearStickyMods()
+            return true
+        }
+        return false
+    }
+}
+
+extension Ghostty.Mods {
+    /// Translate UIKit hardware-keyboard modifier flags to ghostty modifiers.
+    static func fromHardware(_ flags: UIKeyModifierFlags) -> Ghostty.Mods {
+        var mods: Ghostty.Mods = .none
+        if flags.contains(.shift) { mods.insert(.shift) }
+        if flags.contains(.control) { mods.insert(.ctrl) }
+        if flags.contains(.alternate) { mods.insert(.alt) }
+        if flags.contains(.command) { mods.insert(.super) }
+        return mods
+    }
+}
+
+extension Ghostty.Key {
+    /// Map an iOS HID usage code (from `UIKey.keyCode`) to a physical key.
+    init?(hid: UIKeyboardHIDUsage) {
+        switch hid {
+        // Letters
+        case .keyboardA: self = .a; case .keyboardB: self = .b; case .keyboardC: self = .c
+        case .keyboardD: self = .d; case .keyboardE: self = .e; case .keyboardF: self = .f
+        case .keyboardG: self = .g; case .keyboardH: self = .h; case .keyboardI: self = .i
+        case .keyboardJ: self = .j; case .keyboardK: self = .k; case .keyboardL: self = .l
+        case .keyboardM: self = .m; case .keyboardN: self = .n; case .keyboardO: self = .o
+        case .keyboardP: self = .p; case .keyboardQ: self = .q; case .keyboardR: self = .r
+        case .keyboardS: self = .s; case .keyboardT: self = .t; case .keyboardU: self = .u
+        case .keyboardV: self = .v; case .keyboardW: self = .w; case .keyboardX: self = .x
+        case .keyboardY: self = .y; case .keyboardZ: self = .z
+        // Digits
+        case .keyboard1: self = .d1; case .keyboard2: self = .d2; case .keyboard3: self = .d3
+        case .keyboard4: self = .d4; case .keyboard5: self = .d5; case .keyboard6: self = .d6
+        case .keyboard7: self = .d7; case .keyboard8: self = .d8; case .keyboard9: self = .d9
+        case .keyboard0: self = .d0
+        // Symbols
+        case .keyboardHyphen: self = .minus; case .keyboardEqualSign: self = .equal
+        case .keyboardOpenBracket: self = .bracketLeft; case .keyboardCloseBracket: self = .bracketRight
+        case .keyboardBackslash: self = .backslash; case .keyboardSemicolon: self = .semicolon
+        case .keyboardQuote: self = .quote; case .keyboardGraveAccentAndTilde: self = .backquote
+        case .keyboardComma: self = .comma; case .keyboardPeriod: self = .period
+        case .keyboardSlash: self = .slash
+        // Functional
+        case .keyboardEscape: self = .escape; case .keyboardTab: self = .tab
+        case .keyboardReturnOrEnter, .keypadEnter: self = .enter
+        case .keyboardDeleteOrBackspace: self = .backspace
+        case .keyboardDeleteForward: self = .delete; case .keyboardSpacebar: self = .space
+        // Navigation
+        case .keyboardUpArrow: self = .up; case .keyboardDownArrow: self = .down
+        case .keyboardLeftArrow: self = .left; case .keyboardRightArrow: self = .right
+        case .keyboardHome: self = .home; case .keyboardEnd: self = .end
+        case .keyboardPageUp: self = .pageUp; case .keyboardPageDown: self = .pageDown
+        case .keyboardInsert: self = .insert
+        // Function row
+        case .keyboardF1: self = .f1; case .keyboardF2: self = .f2; case .keyboardF3: self = .f3
+        case .keyboardF4: self = .f4; case .keyboardF5: self = .f5; case .keyboardF6: self = .f6
+        case .keyboardF7: self = .f7; case .keyboardF8: self = .f8; case .keyboardF9: self = .f9
+        case .keyboardF10: self = .f10; case .keyboardF11: self = .f11; case .keyboardF12: self = .f12
+        default: return nil
+        }
+    }
+}

--- a/Sources/Ghostty/TerminalSurfaceView+Input.swift
+++ b/Sources/Ghostty/TerminalSurfaceView+Input.swift
@@ -12,8 +12,8 @@ extension TerminalSurfaceView: UIKeyInput {
         // event so combos like Ctrl-C produce the right control bytes.
         if !stickyMods.isEmpty {
             for ch in text {
-                if let key = Ghostty.Key(character: ch) {
-                    sendKey(key, mods: stickyMods)
+                if let (key, shift) = Ghostty.Key.physical(for: ch) {
+                    sendKey(key, mods: shift ? stickyMods.union(.shift) : stickyMods)
                 } else {
                     sendText(String(ch))
                 }

--- a/Sources/Ghostty/TerminalSurfaceView.swift
+++ b/Sources/Ghostty/TerminalSurfaceView.swift
@@ -177,14 +177,20 @@ final class TerminalSurfaceView: UIView {
     }
 
     /// Insert a printable symbol from the accessory bar, applying armed
-    /// modifiers if any (e.g. Ctrl-/).
+    /// modifiers if any (e.g. Ctrl-/, Alt-|).
     func insertSymbol(_ s: String) {
-        if !stickyMods.isEmpty, let ch = s.first, let key = Ghostty.Key(character: ch) {
-            sendKey(key, mods: stickyMods)
-            clearStickyMods()
+        guard !stickyMods.isEmpty else {
+            sendText(s)
+            return
+        }
+        if let ch = s.first, let (key, shift) = Ghostty.Key.physical(for: ch) {
+            sendKey(key, mods: shift ? stickyMods.union(.shift) : stickyMods)
         } else {
+            // Can't encode as a key event; send as text but still consume the
+            // armed modifiers so the accessory bar doesn't show a stuck state.
             sendText(s)
         }
+        clearStickyMods()
     }
 
     /// Current terminal grid size (columns, rows). Falls back to 80x24 before
@@ -220,9 +226,14 @@ final class TerminalSurfaceView: UIView {
 
     /// Send a key press through ghostty's encoder (mode-aware). Use for special
     /// keys (arrows, esc, tab, enter, ...) and control combos (Ctrl-C).
-    func sendKey(_ key: Ghostty.Key, mods: Ghostty.Mods = .none, text: String? = nil) {
+    func sendKey(
+        _ key: Ghostty.Key,
+        mods: Ghostty.Mods = .none,
+        action: Ghostty.KeyAction = .press,
+        text: String? = nil
+    ) {
         guard let surface else { return }
-        let ev = Ghostty.KeyEvent(key: key, action: .press, mods: mods, text: text)
+        let ev = Ghostty.KeyEvent(key: key, action: action, mods: mods, text: text)
         ev.withCValue { c in
             _ = ghostty_surface_key(surface, c)
         }

--- a/Sources/SSH/KnownHosts.swift
+++ b/Sources/SSH/KnownHosts.swift
@@ -1,14 +1,43 @@
 import Foundation
+import Crypto
 import NIOCore
 import NIOSSH
 
 enum HostKeyError: Error, CustomStringConvertible {
     case changed(host: String)
+    case rejected(host: String)
     var description: String {
         switch self {
         case .changed(let host):
             return "Host key for \(host) has CHANGED. This could be a man-in-the-middle attack. Refusing to connect."
+        case .rejected(let host):
+            return "Host key for \(host) was not trusted. Connection cancelled."
         }
+    }
+}
+
+/// A request to the user to make a trust decision about a host key.
+struct HostKeyPrompt {
+    enum Kind: Equatable { case firstUse, changed }
+    let kind: Kind
+    let host: String
+    /// SHA256 fingerprint of the key being presented now.
+    let fingerprint: String
+    /// SHA256 fingerprint of the previously-trusted key (only for `.changed`).
+    let previousFingerprint: String?
+}
+
+/// Computes the OpenSSH-style SHA256 fingerprint (`SHA256:base64…`) of a public
+/// key from its OpenSSH string form (`ssh-ed25519 AAAA… comment`).
+enum SSHFingerprint {
+    static func sha256(ofOpenSSH openSSH: String) -> String {
+        let fields = openSSH.split(separator: " ", omittingEmptySubsequences: true)
+        guard fields.count >= 2, let blob = Data(base64Encoded: String(fields[1])) else {
+            return "SHA256:<unknown>"
+        }
+        let digest = SHA256.hash(data: blob)
+        let b64 = Data(digest).base64EncodedString().replacingOccurrences(of: "=", with: "")
+        return "SHA256:" + b64
     }
 }
 
@@ -30,30 +59,83 @@ final class KnownHostsStore {
     }
 }
 
-/// Trust-on-first-use host-key verification. The first key seen for a host is
-/// remembered and accepted; a later mismatch is rejected (the connection fails
-/// with HostKeyError.changed). A future enhancement is an interactive prompt on
-/// first use / on change.
+/// Trust-on-first-use host-key verification with an interactive prompt. The
+/// first key seen for a host (and any later *changed* key) is surfaced to the
+/// user — with its SHA256 fingerprint — for an explicit accept/reject decision
+/// before the connection is allowed to proceed. Accepted keys are persisted and
+/// not re-prompted.
 final class TOFUHostKeyDelegate: NIOSSHClientServerAuthenticationDelegate {
+    /// Asks the UI to make a trust decision. Invoked on the main thread; the
+    /// completion may be called from any thread (promise completion is
+    /// thread-safe in NIO).
+    typealias Prompt = (HostKeyPrompt, @escaping (_ accept: Bool) -> Void) -> Void
+
     private let hostID: String
     private let store: KnownHostsStore
+    private let prompt: Prompt?
 
-    init(hostID: String, store: KnownHostsStore = KnownHostsStore()) {
+    init(hostID: String, store: KnownHostsStore = KnownHostsStore(), prompt: Prompt? = nil) {
         self.hostID = hostID
         self.store = store
+        self.prompt = prompt
     }
 
     func validateHostKey(hostKey: NIOSSHPublicKey, validationCompletePromise: EventLoopPromise<Void>) {
         let presented = String(openSSHPublicKey: hostKey)
+        let fingerprint = SSHFingerprint.sha256(ofOpenSSH: presented)
+
         if let known = store.key(for: hostID) {
             if known == presented {
                 validationCompletePromise.succeed(())
-            } else {
-                validationCompletePromise.fail(HostKeyError.changed(host: hostID))
+                return
             }
+            let previous = SSHFingerprint.sha256(ofOpenSSH: known)
+            ask(
+                HostKeyPrompt(kind: .changed, host: hostID, fingerprint: fingerprint, previousFingerprint: previous),
+                onReject: .changed(host: hostID),
+                presented: presented,
+                promise: validationCompletePromise
+            )
         } else {
-            store.remember(presented, for: hostID)
-            validationCompletePromise.succeed(())
+            ask(
+                HostKeyPrompt(kind: .firstUse, host: hostID, fingerprint: fingerprint, previousFingerprint: nil),
+                onReject: .rejected(host: hostID),
+                presented: presented,
+                promise: validationCompletePromise
+            )
+        }
+    }
+
+    private func ask(
+        _ request: HostKeyPrompt,
+        onReject: HostKeyError,
+        presented: String,
+        promise: EventLoopPromise<Void>
+    ) {
+        // No UI hook (e.g. headless): preserve safe defaults — trust on first
+        // use, refuse a changed key.
+        guard let prompt else {
+            switch request.kind {
+            case .firstUse:
+                store.remember(presented, for: hostID)
+                promise.succeed(())
+            case .changed:
+                promise.fail(onReject)
+            }
+            return
+        }
+
+        let store = self.store
+        let hostID = self.hostID
+        DispatchQueue.main.async {
+            prompt(request) { accept in
+                if accept {
+                    store.remember(presented, for: hostID)
+                    promise.succeed(())
+                } else {
+                    promise.fail(onReject)
+                }
+            }
         }
     }
 }

--- a/Sources/SSH/SSHSession.swift
+++ b/Sources/SSH/SSHSession.swift
@@ -33,6 +33,7 @@ final class SSHSession: TerminalSession {
     private let connection: SSHConnection
     private weak var view: TerminalSurfaceView?
     private let onStateChange: (SSHSessionState) -> Void
+    private let onHostKeyPrompt: TOFUHostKeyDelegate.Prompt?
 
     private let group: EventLoopGroup
     private var channel: Channel?
@@ -42,10 +43,12 @@ final class SSHSession: TerminalSession {
     init(
         connection: SSHConnection,
         view: TerminalSurfaceView,
+        onHostKeyPrompt: TOFUHostKeyDelegate.Prompt? = nil,
         onStateChange: @escaping (SSHSessionState) -> Void
     ) {
         self.connection = connection
         self.view = view
+        self.onHostKeyPrompt = onHostKeyPrompt
         self.onStateChange = onStateChange
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     }
@@ -77,7 +80,8 @@ final class SSHSession: TerminalSession {
 
         let authDelegate = OrderedAuthDelegate(username: connection.username, offers: offers)
         let hostKeyDelegate = TOFUHostKeyDelegate(
-            hostID: "\(connection.host):\(connection.port)"
+            hostID: "\(connection.host):\(connection.port)",
+            prompt: onHostKeyPrompt
         )
 
         let bootstrap = ClientBootstrap(group: group)

--- a/Sources/UI/TerminalScreen.swift
+++ b/Sources/UI/TerminalScreen.swift
@@ -1,5 +1,12 @@
 import SwiftUI
 
+/// A pending host-key trust decision surfaced to the UI, pairing the prompt
+/// details with the callback that resumes the SSH handshake.
+struct HostKeyPromptRequest {
+    let prompt: HostKeyPrompt
+    let decide: (Bool) -> Void
+}
+
 /// Full-screen terminal for an active SSH connection, with a slim status bar
 /// and a close button.
 struct TerminalScreen: View {
@@ -8,18 +15,72 @@ struct TerminalScreen: View {
     let onClose: () -> Void
 
     @State private var state: SSHSessionState = .idle
+    @State private var hostKeyRequest: HostKeyPromptRequest?
 
     var body: some View {
         VStack(spacing: 0) {
             statusBar
             TerminalView(ghostty: ghostty) { view in
-                SSHSession(connection: connection, view: view) { newState in
+                SSHSession(
+                    connection: connection,
+                    view: view,
+                    onHostKeyPrompt: { prompt, decide in
+                        hostKeyRequest = HostKeyPromptRequest(prompt: prompt, decide: decide)
+                    }
+                ) { newState in
                     state = newState
                 }
             }
         }
         .background(Color.black.ignoresSafeArea())
         .preferredColorScheme(.dark)
+        .alert(
+            hostKeyRequest?.prompt.kind == .changed ? "Host Key Changed" : "Unknown Host",
+            isPresented: Binding(
+                get: { hostKeyRequest != nil },
+                set: { if !$0 { hostKeyRequest?.decide(false); hostKeyRequest = nil } }
+            ),
+            presenting: hostKeyRequest
+        ) { request in
+            let isChanged = request.prompt.kind == .changed
+            Button(isChanged ? "Accept New Key" : "Trust", role: isChanged ? .destructive : nil) {
+                request.decide(true)
+                hostKeyRequest = nil
+            }
+            Button("Cancel", role: .cancel) {
+                request.decide(false)
+                hostKeyRequest = nil
+            }
+        } message: { request in
+            Text(hostKeyMessage(request.prompt))
+        }
+    }
+
+    private func hostKeyMessage(_ prompt: HostKeyPrompt) -> String {
+        switch prompt.kind {
+        case .firstUse:
+            return """
+            The authenticity of host \(prompt.host) can't be established.
+
+            Key fingerprint:
+            \(prompt.fingerprint)
+
+            Trust this host and continue connecting?
+            """
+        case .changed:
+            return """
+            ⚠️ The host key for \(prompt.host) has changed. This may indicate a \
+            man-in-the-middle attack, or the server may simply have been reinstalled.
+
+            Previously trusted:
+            \(prompt.previousFingerprint ?? "<unknown>")
+
+            New fingerprint:
+            \(prompt.fingerprint)
+
+            Only accept if you expected this change.
+            """
+        }
     }
 
     @ViewBuilder private var statusBar: some View {


### PR DESCRIPTION
## Summary

Fixes the confirmed findings from a static verification pass over every required function of the app. The core architecture (passthru SSH↔ghostty bridge, connection/key persistence, SSH auth) was already correct; these changes close the edge gaps.

## Fixes

- **Hardware keyboard** (new `TerminalSurfaceView+Hardware.swift`): implement `pressesBegan/Ended/Cancelled` with a full `UIKeyboardHIDUsage`→`Ghostty.Key` map and `UIKeyModifierFlags`→`Mods` translation. Special keys and Ctrl/Alt/Cmd combos route through `ghostty_surface_key`; plain/Shift-only keys defer to `UIKeyInput.insertText` so nothing is double-sent. Honors accessory-bar sticky mods.
- **Host-key TOFU prompt**: interactive accept/reject with SHA256 fingerprints for first-use and changed keys (MITM warning + destructive "Accept New Key"), persisting the decision. Falls back to trust-first / refuse-changed when no UI hook is present (headless).
- **Rendering**: drive `ghostty_app_tick` from a `CADisplayLink` (weak proxy avoids a retain cycle) in addition to the on-demand wakeup callback.
- **Accessory keyboard**: add a `Del` key and an `Fn` toggle that reveals an F1–F12 row.
- **Sticky modifiers**: map the shifted symbol row (`| ~ : _` and the rest) to base key + Shift so `Ctrl-_`/`Alt-|` encode correctly, and always clear armed mods so the bar can no longer get visually stuck.

The one "missing flush" finding was intentionally left alone — NIO handlers should not flush inside the pipeline (the `writeAndFlush` is correctly at the channel entry point).

## Testing

`xcodegen generate` + `xcodebuild -sdk iphonesimulator … build` → **BUILD SUCCEEDED** (only the pre-existing NIO Sendable warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)