### PR TITLE
build: vendor the ghostty engine as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ghostty"]
+	path = ghostty
+	url = https://github.com/madeye/ghostty.git

--- a/README.md
+++ b/README.md
@@ -30,14 +30,15 @@ brew install xcodegen
 
 0. Get the terminal engine. gterm uses a fork of ghostty that adds a
    `passthru` IO backend (so the terminal can be driven by SSH instead of a
-   local shell). Clone it next to this repo:
+   local shell). It's bundled as a git submodule — check it out with:
 
    ```sh
-   git clone https://github.com/madeye/ghostty.git ../ghostty
+   git submodule update --init ghostty
    ```
 
-   (Or clone it elsewhere and pass `GHOSTTY_DIR=/path/to/ghostty` to the build
-   script below.)
+   (If you cloned without `--recurse-submodules`, the command above fetches it.
+   To use a separate checkout instead, pass `GHOSTTY_DIR=/path/to/ghostty` to
+   the build script below.)
 
 1. Build the terminal engine (cross-compiles `GhosttyKit.xcframework` with
    macOS + iOS + iOS-simulator slices, and applies the required iOS patch to

--- a/scripts/build-ghostty-xcframework.sh
+++ b/scripts/build-ghostty-xcframework.sh
@@ -4,7 +4,7 @@
 #
 # gterm renders its terminal using ghostty's libghostty engine, cross-compiled
 # to a static-library xcframework with macOS + iOS-device + iOS-simulator
-# slices. This script builds it from the sibling ghostty checkout and copies
+# slices. This script builds it from the bundled `ghostty` submodule and copies
 # the result next to this repo so the Xcode project can link it.
 #
 # Toolchain quirks on this machine (see also the project memory):
@@ -18,7 +18,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GTERM_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-GHOSTTY_DIR="${GHOSTTY_DIR:-$(cd "$GTERM_DIR/.." && pwd)/ghostty}"
+# Default to the in-repo `ghostty` submodule. Override with GHOSTTY_DIR to point
+# at a separate checkout (e.g. for local engine development).
+GHOSTTY_DIR="${GHOSTTY_DIR:-$GTERM_DIR/ghostty}"
 
 ZIG="${ZIG:-/opt/homebrew/opt/zig@0.15/bin/zig}"
 
@@ -28,9 +30,10 @@ if [[ ! -x "$ZIG" ]]; then
   exit 1
 fi
 
-if [[ ! -d "$GHOSTTY_DIR" ]]; then
-  echo "error: ghostty checkout not found at $GHOSTTY_DIR" >&2
-  echo "       set GHOSTTY_DIR=/path/to/ghostty" >&2
+if [[ ! -d "$GHOSTTY_DIR" || -z "$(ls -A "$GHOSTTY_DIR" 2>/dev/null)" ]]; then
+  echo "error: ghostty submodule not checked out at $GHOSTTY_DIR" >&2
+  echo "       run: git submodule update --init ghostty" >&2
+  echo "       (or set GHOSTTY_DIR=/path/to/ghostty for a separate checkout)" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Pins the libghostty engine fork as a git submodule instead of requiring a manual sibling clone.

## Changes
- **Add `ghostty` submodule** → `https://github.com/madeye/ghostty.git`, pinned at `main` `ea0622bc` (the libghostty **passthru-IO** commit — same one the build was using from `../ghostty`).
- **`scripts/build-ghostty-xcframework.sh`** — `GHOSTTY_DIR` now defaults to `$GTERM_DIR/ghostty` (the submodule). The `GHOSTTY_DIR=...` override is unchanged. Error message now points at `git submodule update --init ghostty` and also catches an un-checked-out (empty) submodule.
- **README** — setup step inits the submodule instead of cloning a sibling.

## Use
```sh
git clone --recurse-submodules https://github.com/madeye/gterm.git
# or, in an existing checkout:
git submodule update --init ghostty
./scripts/build-ghostty-xcframework.sh
```

> Verified by inspection (`GHOSTTY_DIR` resolves to the submodule; pin matches the prior `../ghostty` commit). I did **not** run the full `zig@0.15` cross-compile of GhosttyKit here.