### PR TITLE
ci: build GhosttyKit engine on PRs (with submodules)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,56 @@
+name: build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+# Cancel superseded runs on the same ref.
+concurrency:
+  group: build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  engine:
+    name: GhosttyKit engine
+    runs-on: macos-15
+    timeout-minutes: 60
+    steps:
+      - name: Checkout (with submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Verify ghostty submodule
+        run: |
+          if [ ! -f ghostty/build.zig ]; then
+            echo "::error::ghostty submodule is not checked out (ghostty/build.zig missing)"
+            exit 1
+          fi
+          echo "ghostty pinned at $(git -C ghostty rev-parse HEAD)"
+
+      - name: Install zig 0.15
+        run: brew install zig@0.15
+
+      # libghostty + its zig deps land in ~/.cache/zig; keyed on the engine's
+      # dependency manifest + build graph so a cache hit skips the slow
+      # fetch/compile and only invalidates when the submodule bumps.
+      - name: Cache zig build
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/zig
+          key: zig-${{ runner.os }}-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig') }}
+          restore-keys: |
+            zig-${{ runner.os }}-
+
+      - name: Build GhosttyKit.xcframework
+        run: ./scripts/build-ghostty-xcframework.sh
+
+      - name: Upload GhosttyKit.xcframework
+        uses: actions/upload-artifact@v4
+        with:
+          name: GhosttyKit-xcframework
+          path: GhosttyKit.xcframework
+          if-no-files-found: error
+          retention-days: 7


### PR DESCRIPTION
Adds `.github/workflows/build.yml` — checks out submodules and runs the engine build on every PR, so a broken submodule or engine no longer slips through.

- **macos-15** runner, `submodules: recursive`.
- Fails fast if the `ghostty` submodule isn't checked out.
- Installs `zig@0.15`, caches `~/.cache/zig` (keyed on the submodule's `build.zig.zon`/`build.zig`).
- Runs `scripts/build-ghostty-xcframework.sh` and uploads `GhosttyKit.xcframework` as an artifact.

This PR run is itself the first validation of the workflow.

> Scope is the engine build (per request). The app `xcodebuild` step is intentionally left out for now — hosted runners may not have the Xcode 26 / iOS 26 SDK the app targets; happy to add it behind a self-hosted runner.