### PR TITLE
Use unique App Store listing name (gterm: Ghostty SSH)

### DIFF
--- a/fastlane/metadata/en-US/name.txt
+++ b/fastlane/metadata/en-US/name.txt
@@ -1,1 +1,1 @@
-gterm
+gterm: Ghostty SSH


### PR DESCRIPTION
App Store listing names are globally unique, and "gterm" is already taken by
another account — `deliver` was rejected uploading the app-info localization
(`/data/attributes/name`). Use **gterm: Ghostty SSH** as the storefront name;
the in-app `CFBundleDisplayName` stays "gterm".

Verified: after this change, `deliver` uploads the name/subtitle/privacy URL
successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)