### PR TITLE
Gitignore review phone number; quiet deliver precheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ fastlane/Preview.html
 fastlane/test_output/
 fastlane/screenshots/screenshots.html
 *.itmsp
+# Personal App Review contact phone — keep out of the public repo
+fastlane/metadata/review_information/phone_number.txt

--- a/fastlane/Deliverfile
+++ b/fastlane/Deliverfile
@@ -16,5 +16,6 @@ force(false) # show the HTML preview and ask for confirmation
 # We are not shipping a binary from `deliver`; upload metadata + screenshots only.
 skip_binary_upload(true)
 
-# This app collects no analytics; keep the existing answer in App Store Connect.
-# precheck_include_in_app_purchases(false)
+# gterm has no in-app purchases; the API-key precheck can't inspect IAPs and
+# would otherwise exit non-zero on an otherwise successful run.
+precheck_include_in_app_purchases(false)


### PR DESCRIPTION
- Untrack and gitignore `fastlane/metadata/review_information/phone_number.txt`
  so the personal App Review contact phone stays out of the public repo. Only
  an empty version was ever committed — no number is in git history.
- `precheck_include_in_app_purchases(false)` in the Deliverfile: the ASC API
  key can't inspect in-app purchases, which made an otherwise-successful
  `deliver` run exit non-zero. gterm has no IAPs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)