### PR TITLE
Drop duplicate ASSETCATALOG_COMPILER_APPICON_NAME key

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -78,7 +78,6 @@ targets:
         # team provides this; the entitlements file declares the keychain group.
         CODE_SIGN_ENTITLEMENTS: gterm.entitlements
         CODE_SIGN_STYLE: Automatic
-        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         # GhosttyKit is a static Zig library; -ObjC pulls in its ObjC categories
         # and -lstdc++ satisfies the C++ (simdutf/highway) bits it links.
         OTHER_LDFLAGS: [-ObjC, -lstdc++]


### PR DESCRIPTION
Cosmetic cleanup after the AI merge: the gterm target had two identical `ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon` entries. Remove the duplicate (YAML took the last anyway, so no build change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)