### PR TITLE
Add TestFlight beta link to landing page & README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 An iOS terminal app that renders with [ghostty](../ghostty)'s `libghostty`
 engine (GPU/Metal, full xterm/VT emulation) and connects over **SSH**.
 
+> 📲 **Try the beta:** [Join on TestFlight](https://testflight.apple.com/join/qDNYS7fd) (iOS 17+, requires Apple's TestFlight app).
+
 iOS can't `fork`/`exec` a local shell, so gterm drives the terminal from an SSH
 connection via a custom **passthru IO backend** added to libghostty. See
 [PLAN.md](PLAN.md) for the full architecture.

--- a/docs/index.html
+++ b/docs/index.html
@@ -165,10 +165,11 @@
       <a href="#features">Features</a>
       <a href="#engine">Engine</a>
       <a href="#shots">Screens</a>
+      <a href="https://github.com/madeye/gterm">GitHub</a>
     </div>
-    <a class="btn btn-primary" href="https://github.com/madeye/gterm">
-      <svg width="17" height="17" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38v-1.34c-2.23.48-2.7-1.07-2.7-1.07-.36-.92-.89-1.17-.89-1.17-.73-.5.05-.49.05-.49.81.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.28.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48v2.2c0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
-      GitHub
+    <a class="btn btn-primary" href="https://testflight.apple.com/join/qDNYS7fd">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M2.4 11.4 21.5 2.5 12.6 21.6l-2.8-8-7-2.2Z"/></svg>
+      TestFlight
     </a>
   </div>
 </nav>
@@ -180,10 +181,10 @@
     <h1>A real terminal<br/>in your pocket,<br/><span class="grad-text">over SSH.</span></h1>
     <p class="lead"><b>gterm</b> renders with Ghostty's GPU engine for true xterm/VT emulation, connects straight to your servers over SSH, keeps your keys on-device, and ships an <b>AI command assistant</b> that writes the commands for you.</p>
     <div class="cta-row">
-      <a class="btn btn-primary" href="https://github.com/madeye/gterm">Get it on GitHub →</a>
-      <a class="btn btn-ghost" href="#features">See what it does</a>
+      <a class="btn btn-primary" href="https://testflight.apple.com/join/qDNYS7fd">Join the TestFlight beta →</a>
+      <a class="btn btn-ghost" href="https://github.com/madeye/gterm">View on GitHub</a>
     </div>
-    <div class="cta-note"><span class="dot" style="background:var(--violet);box-shadow:0 0 10px var(--violet-bright)"></span> Ed25519 / ECDSA keys · trust-on-first-use host keys · device-only</div>
+    <div class="cta-note"><span class="dot" style="background:var(--violet);box-shadow:0 0 10px var(--violet-bright)"></span> Free public beta · needs Apple's TestFlight app · iOS 17+</div>
   </div>
 
   <div class="term" aria-hidden="true">
@@ -282,6 +283,7 @@ README.md&nbsp;&nbsp;app.py&nbsp;&nbsp;package.json&nbsp;&nbsp;<span class="pth"
   <div class="wrap">
     <a class="brand" href="#top"><img src="assets/icon.png" alt="" /> gterm</a>
     <div class="foot-links">
+      <a href="https://testflight.apple.com/join/qDNYS7fd">TestFlight beta</a>
       <a href="https://github.com/madeye/gterm">GitHub</a>
       <a href="https://github.com/madeye/gterm/blob/main/PLAN.md">Architecture</a>
       <a href="https://github.com/madeye/ghostty">Ghostty fork</a>


### PR DESCRIPTION
The 1.0 beta is live on TestFlight (https://testflight.apple.com/join/qDNYS7fd). Adds it as the primary CTA in the nav and hero, in the footer, and as a callout in the README; GitHub becomes a secondary link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)