### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Max Lv
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -64,4 +64,13 @@ brew install xcodegen
 `gterm.xcodeproj`, `Info.plist`, and `GhosttyKit.xcframework` are generated and
 git-ignored.
 
+## License
+
+gterm is released under the [MIT License](LICENSE) © 2026 Max Lv.
+
+Bundled / dependency components keep their own licenses: the
+[ghostty](https://github.com/madeye/ghostty) engine is MIT; swift-nio-ssh,
+swift-crypto, and swift-nio are Apache-2.0; the OpenAI and SwiftAnthropic SDKs
+are MIT.
+
 


### PR DESCRIPTION
Adds a top-level `LICENSE` (MIT, © 2026 Max Lv) and a README License section noting dependency licenses (ghostty MIT; swift-nio-ssh/crypto/nio Apache-2.0; OpenAI/SwiftAnthropic MIT). GitHub will now detect the repo license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)