### PR TITLE
SSH port forwarding, in-app browser, and tap-to-open URLs

### DIFF
--- a/Sources/Browser/WebView.swift
+++ b/Sources/Browser/WebView.swift
@@ -1,0 +1,129 @@
+import Foundation
+import SwiftUI
+import WebKit
+
+/// Observable model wrapping a single `WKWebView`, exposing navigation state to
+/// SwiftUI chrome (address bar, progress, back/forward, errors).
+final class WebViewModel: ObservableObject {
+    @Published var url: URL?
+    @Published var title: String = ""
+    @Published var progress: Double = 0
+    @Published var isLoading: Bool = false
+    @Published var canGoBack: Bool = false
+    @Published var canGoForward: Bool = false
+    @Published var lastError: String?
+
+    let webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+
+    func load(_ u: URL) {
+        lastError = nil
+        webView.load(URLRequest(url: u))
+    }
+
+    func goBack() { webView.goBack() }
+    func goForward() { webView.goForward() }
+
+    func reload() {
+        lastError = nil
+        webView.reload()
+    }
+
+    func stop() {
+        webView.stopLoading()
+        isLoading = false
+    }
+}
+
+/// Bridges the model's `WKWebView` into SwiftUI and wires up navigation + KVO.
+struct WebViewRepresentable: UIViewRepresentable {
+    @ObservedObject var model: WebViewModel
+
+    func makeUIView(context: Context) -> WKWebView {
+        let webView = model.webView
+        webView.navigationDelegate = context.coordinator
+        context.coordinator.observe(webView)
+        return webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        // no-op: navigation is driven imperatively through the model.
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(model: model)
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate {
+        private let model: WebViewModel
+        // NSKeyValueObservation tokens auto-invalidate on deinit, avoiding the
+        // manual removeObserver footgun.
+        private var observations: [NSKeyValueObservation] = []
+
+        init(model: WebViewModel) {
+            self.model = model
+        }
+
+        func observe(_ webView: WKWebView) {
+            observations = [
+                webView.observe(\.estimatedProgress, options: [.new]) { [weak self] wv, _ in
+                    DispatchQueue.main.async { self?.model.progress = wv.estimatedProgress }
+                },
+                webView.observe(\.canGoBack, options: [.new]) { [weak self] wv, _ in
+                    DispatchQueue.main.async { self?.model.canGoBack = wv.canGoBack }
+                },
+                webView.observe(\.canGoForward, options: [.new]) { [weak self] wv, _ in
+                    DispatchQueue.main.async { self?.model.canGoForward = wv.canGoForward }
+                },
+                webView.observe(\.title, options: [.new]) { [weak self] wv, _ in
+                    DispatchQueue.main.async { self?.model.title = wv.title ?? "" }
+                },
+                webView.observe(\.url, options: [.new]) { [weak self] wv, _ in
+                    DispatchQueue.main.async { self?.model.url = wv.url }
+                },
+            ]
+        }
+
+        deinit {
+            observations.forEach { $0.invalidate() }
+        }
+
+        // MARK: WKNavigationDelegate
+
+        func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+            DispatchQueue.main.async {
+                self.model.isLoading = true
+                self.model.lastError = nil
+            }
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            DispatchQueue.main.async {
+                self.model.isLoading = false
+            }
+        }
+
+        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+            DispatchQueue.main.async {
+                self.model.isLoading = false
+                self.model.lastError = error.localizedDescription
+            }
+        }
+
+        func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+            DispatchQueue.main.async {
+                self.model.isLoading = false
+                self.model.lastError = error.localizedDescription
+            }
+        }
+    }
+}
+
+/// If `string` lacks a URL scheme, prepend `http://`. Used by the address bar.
+func normalized(_ string: String) -> URL? {
+    let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    if trimmed.contains("://") {
+        return URL(string: trimmed)
+    }
+    return URL(string: "http://\(trimmed)")
+}

--- a/Sources/Ghostty/GhosttyApp.swift
+++ b/Sources/Ghostty/GhosttyApp.swift
@@ -131,6 +131,17 @@ extension Ghostty {
                 DispatchQueue.main.async { view.didChangePwd(pwd) }
                 return true
 
+            case GHOSTTY_ACTION_OPEN_URL:
+                guard target.tag == GHOSTTY_TARGET_SURFACE,
+                      let view = surfaceView(target.target.surface),
+                      let cstr = action.action.open_url.url else { return false }
+                let len = Int(action.action.open_url.len)
+                let url = len > 0
+                    ? String(decoding: UnsafeRawBufferPointer(start: cstr, count: len), as: UTF8.self)
+                    : String(cString: cstr)
+                DispatchQueue.main.async { view.didRequestOpenURL(url) }
+                return true
+
             default:
                 // Many actions are macOS/window-manager specific and don't
                 // apply on iOS. Returning false marks them unperformed.

--- a/Sources/Ghostty/TerminalSurfaceView+Link.swift
+++ b/Sources/Ghostty/TerminalSurfaceView+Link.swift
@@ -1,0 +1,31 @@
+import UIKit
+import GhosttyKit
+
+/// Tap-to-open-URL support. libghostty detects links (auto-detected URLs and
+/// OSC 8 hyperlinks) and opens the one under the cursor on a left-click release,
+/// but only treats a cell as "over a link" when the mouse modifiers match
+/// `ctrlOrSuper` — which is `super` (⌘) on Apple platforms. iOS has no hover, so
+/// a single tap synthesizes a super-modified move + click at the tapped point;
+/// if a link is there, libghostty fires the OPEN_URL action (handled in
+/// `Ghostty.App.action`), which we route to the in-app browser. A tap on a
+/// non-link is a harmless super-click.
+extension TerminalSurfaceView {
+    func setupLinkTapGesture() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(handleLinkTap(_:)))
+        tap.numberOfTapsRequired = 1
+        tap.numberOfTouchesRequired = 1
+        addGestureRecognizer(tap)
+    }
+
+    @objc private func handleLinkTap(_ gesture: UITapGestureRecognizer) {
+        guard gesture.state == .ended, let surface = ghosttySurface else { return }
+        let loc = gesture.location(in: self)
+        let superMods = GHOSTTY_MODS_SUPER
+        // Move with super so the cell registers as over_link, then click it.
+        ghostty_surface_mouse_pos(surface, Double(loc.x), Double(loc.y), superMods)
+        _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, superMods)
+        _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, superMods)
+        // Clear the hover modifiers so the link highlight doesn't stick.
+        ghostty_surface_mouse_pos(surface, Double(loc.x), Double(loc.y), Ghostty.Mods.none.cMods)
+    }
+}

--- a/Sources/Ghostty/TerminalSurfaceView.swift
+++ b/Sources/Ghostty/TerminalSurfaceView.swift
@@ -78,6 +78,20 @@ final class TerminalSurfaceView: UIView {
         self.surface = surface
         setupSelectionGestures()
         setupScrollGesture()
+        setupLinkTapGesture()
+    }
+
+    // MARK: Link opening
+
+    /// Called when the user taps a URL in the terminal; the SwiftUI layer routes
+    /// it to the in-app browser. Set by the hosting view.
+    var onOpenURL: ((URL) -> Void)?
+
+    /// Invoked from libghostty's OPEN_URL action (via Ghostty.App) when a clicked
+    /// link is followed. Parses and forwards the URL on the main thread.
+    func didRequestOpenURL(_ string: String) {
+        guard let url = URL(string: string) else { return }
+        onOpenURL?(url)
     }
 
     // MARK: Selection / clipboard gesture state (see TerminalSurfaceView+Selection)

--- a/Sources/Model/PortForwardStore.swift
+++ b/Sources/Model/PortForwardStore.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// A persisted port-forward configuration (metadata only, no secrets). Mirrors
+/// `SavedConnection`/`ConnectionStore`: configs live in UserDefaults JSON keyed
+/// by the owning connection's id. Runtime status is never persisted here.
+struct PortForward: Identifiable, Codable, Equatable {
+    var id = UUID()
+    /// FK -> SavedConnection.id (NOT defaulted: a forward always belongs to a connection).
+    var connectionID: UUID
+    var name: String = ""
+    /// 127.0.0.1:localPort listener on the device.
+    var localPort: Int = 8080
+    /// Target host as seen FROM the SSH server.
+    var remoteHost: String = "127.0.0.1"
+    var remotePort: Int = 80
+    /// Bind the listener as soon as the session connects.
+    var autoStart: Bool = false
+    /// "http" | "https"; builds the browser URL.
+    var scheme: String = "http"
+
+    var title: String { name.isEmpty ? "\(localPort) \u{2192} \(remoteHost):\(remotePort)" : name }
+    var subtitle: String { "127.0.0.1:\(localPort) \u{2192} \(remoteHost):\(remotePort)" }
+    var localURL: URL? { URL(string: "\(scheme)://127.0.0.1:\(localPort)/") }
+    var isWeb: Bool { scheme == "http" || scheme == "https" }
+}
+
+/// Stores port-forward configs (metadata in UserDefaults). No Keychain: forwards
+/// hold no secrets. Keyed conceptually by `connectionID`.
+final class PortForwardStore: ObservableObject {
+    @Published private(set) var forwards: [PortForward] = []
+
+    private let key = "portForwards"
+
+    init() { load() }
+
+    private func load() {
+        guard let data = UserDefaults.standard.data(forKey: key),
+              let decoded = try? JSONDecoder().decode([PortForward].self, from: data)
+        else { return }
+        forwards = decoded
+    }
+
+    private func persist() {
+        if let data = try? JSONEncoder().encode(forwards) {
+            UserDefaults.standard.set(data, forKey: key)
+        }
+    }
+
+    /// Forwards belonging to a connection, sorted by local port.
+    func forwards(for connectionID: UUID) -> [PortForward] {
+        forwards
+            .filter { $0.connectionID == connectionID }
+            .sorted { $0.localPort < $1.localPort }
+    }
+
+    /// Upsert by id, then persist. Local-port uniqueness within a connection is
+    /// enforced in the editor UI, not here.
+    func save(_ f: PortForward) {
+        if let idx = forwards.firstIndex(where: { $0.id == f.id }) {
+            forwards[idx] = f
+        } else {
+            forwards.append(f)
+        }
+        persist()
+    }
+
+    func delete(_ f: PortForward) {
+        forwards.removeAll { $0.id == f.id }
+        persist()
+    }
+
+    /// Cascade: remove all forwards belonging to a (deleted) connection.
+    func deleteForwards(for connectionID: UUID) {
+        forwards.removeAll { $0.connectionID == connectionID }
+        persist()
+    }
+}

--- a/Sources/SSH/GlueHandler.swift
+++ b/Sources/SSH/GlueHandler.swift
@@ -1,0 +1,124 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+
+final class GlueHandler {
+    private var partner: GlueHandler?
+
+    private var context: ChannelHandlerContext?
+
+    private var pendingRead: Bool = false
+
+    private init() {}
+}
+
+extension GlueHandler {
+    static func matchedPair() -> (GlueHandler, GlueHandler) {
+        let first = GlueHandler()
+        let second = GlueHandler()
+
+        first.partner = second
+        second.partner = first
+
+        return (first, second)
+    }
+}
+
+extension GlueHandler {
+    private func partnerWrite(_ data: NIOAny) {
+        self.context?.write(data, promise: nil)
+    }
+
+    private func partnerFlush() {
+        self.context?.flush()
+    }
+
+    private func partnerWriteEOF() {
+        self.context?.close(mode: .output, promise: nil)
+    }
+
+    private func partnerCloseFull() {
+        self.context?.close(promise: nil)
+    }
+
+    private func partnerBecameWritable() {
+        if self.pendingRead {
+            self.pendingRead = false
+            self.context?.read()
+        }
+    }
+
+    private var partnerWritable: Bool {
+        self.context?.channel.isWritable ?? false
+    }
+}
+
+extension GlueHandler: ChannelDuplexHandler {
+    typealias InboundIn = NIOAny
+    typealias OutboundIn = NIOAny
+    typealias OutboundOut = NIOAny
+
+    func handlerAdded(context: ChannelHandlerContext) {
+        self.context = context
+
+        // It's possible our partner asked if we were writable, before, and we couldn't answer.
+        // Consider updating it.
+        if context.channel.isWritable {
+            self.partner?.partnerBecameWritable()
+        }
+    }
+
+    func handlerRemoved(context: ChannelHandlerContext) {
+        self.context = nil
+        self.partner = nil
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        self.partner?.partnerWrite(data)
+    }
+
+    func channelReadComplete(context: ChannelHandlerContext) {
+        self.partner?.partnerFlush()
+    }
+
+    func channelInactive(context: ChannelHandlerContext) {
+        self.partner?.partnerCloseFull()
+    }
+
+    func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
+        if let event = event as? ChannelEvent, case .inputClosed = event {
+            // We have read EOF.
+            self.partner?.partnerWriteEOF()
+        }
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        self.partner?.partnerCloseFull()
+    }
+
+    func channelWritabilityChanged(context: ChannelHandlerContext) {
+        if context.channel.isWritable {
+            self.partner?.partnerBecameWritable()
+        }
+    }
+
+    func read(context: ChannelHandlerContext) {
+        if let partner = self.partner, partner.partnerWritable {
+            context.read()
+        } else {
+            self.pendingRead = true
+        }
+    }
+}

--- a/Sources/SSH/PortForwardManager.swift
+++ b/Sources/SSH/PortForwardManager.swift
@@ -1,0 +1,252 @@
+import Foundation
+import NIOCore
+import NIOPosix
+import NIOSSH
+import os
+
+/// Live runtime state of a single port forward, surfaced to the UI.
+enum PortForwardStatus: Equatable {
+    case stopped
+    case starting
+    case listening
+    case failed(String)
+}
+
+/// Errors raised by the port-forwarding mechanism.
+enum PortForwardError: Error {
+    case invalidData
+    case badType
+    case noOriginator
+    case invalidPort
+}
+
+/// The NIO mechanism behind SSH local port forwarding (`ssh -L` semantics).
+///
+/// Owned by `SSHSession`, this reuses the session's authenticated parent channel
+/// and its single-thread `EventLoopGroup`. For each enabled forward it binds a
+/// `ServerBootstrap` listener on `127.0.0.1:localPort`; every inbound TCP
+/// connection opens a `directTCPIP` child channel via the parent's `NIOSSHHandler`
+/// and glues the two byte streams with `SSHWrapperHandler` + `GlueHandler`.
+///
+/// THREADING INVARIANT: this relies on `numberOfThreads == 1`. All mutations of
+/// `listeners` happen on `group.next()`, and `glue(inbound:to:)` adds handlers to
+/// both the inbound TCP child and the SSH child via `syncOperations` on the
+/// assumption that they share one event loop. If the group ever becomes
+/// multi-threaded, the cross-channel `syncOperations` would crash.
+final class PortForwardManager {
+    private let parentChannel: Channel
+    private let group: EventLoopGroup
+    private let onChange: (UUID, PortForwardStatus) -> Void
+
+    /// Live listener (ServerChannel) per forward id. Mutated only on the loop.
+    private var listeners: [UUID: Channel] = [:]
+
+    /// Live inbound TCP child channels per forward id, keyed by ObjectIdentifier.
+    /// Tracked so `stop(id)`/`stopAll()` can tear down in-flight tunnels, not just
+    /// the listener. Mutated only on the loop. Closing the inbound channel triggers
+    /// GlueHandler.channelInactive, which closes the glued SSH child too.
+    private var tunnels: [UUID: [ObjectIdentifier: Channel]] = [:]
+
+    /// Forward ids whose bind is currently in flight, so a second `start` (e.g.
+    /// autoStart racing a manual toggle) is a no-op instead of a duplicate bind.
+    private var starting: Set<UUID> = []
+
+    /// The close future of the most recently stopped listener per id. A re-`start`
+    /// waits on it before re-binding: on Darwin SO_REUSEADDR does NOT permit a
+    /// second bind while the previous listener socket is still open, so a quick
+    /// off->on toggle would otherwise fail with EADDRINUSE.
+    private var closing: [UUID: EventLoopFuture<Void>] = [:]
+
+    private let log = Logger(subsystem: "io.github.madeye.gterm", category: "PortForward")
+
+    init(parentChannel: Channel,
+         group: EventLoopGroup,
+         onChange: @escaping (UUID, PortForwardStatus) -> Void) {
+        self.parentChannel = parentChannel
+        self.group = group
+        self.onChange = onChange
+    }
+
+    /// Dispatch a status change to the main thread for SwiftUI consumption.
+    private func emit(_ id: UUID, _ status: PortForwardStatus) {
+        DispatchQueue.main.async { [onChange] in onChange(id, status) }
+    }
+
+    // MARK: Public API (hops to the loop internally)
+
+    /// Bind a listener for `forward`. Idempotent: no-op if one already exists.
+    func start(_ forward: PortForward) {
+        group.next().execute { [weak self] in
+            guard let self else { return }
+            let id = forward.id
+            // Idempotent: already listening, or a bind is already in flight.
+            if self.listeners[id] != nil || self.starting.contains(id) { return }
+            self.starting.insert(id)
+            self.emit(id, .starting)
+            // Wait for any in-flight close of a prior listener for this id before
+            // re-binding, so a quick off->on toggle doesn't hit EADDRINUSE.
+            let prior = self.closing[id] ?? self.group.next().makeSucceededVoidFuture()
+            prior.hop(to: self.group.next()).whenComplete { [weak self] _ in
+                self?.performBind(forward)
+            }
+        }
+    }
+
+    /// Bind the listener for `forward`. Runs on the loop; assumes `starting`
+    /// already contains the id (cleared here when the bind settles).
+    private func performBind(_ forward: PortForward) {
+        let id = forward.id
+        let bootstrap = ServerBootstrap(group: self.group)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .serverChannelOption(ChannelOptions.backlog, value: 16)
+            .childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
+            // NOTE: autoRead is left ON (default). GlueHandler provides backpressure
+            // by gating those automatic reads in read(context:) — turning autoRead
+            // off instead breaks the data pump (reads are never re-issued).
+            .childChannelInitializer { [weak self] inbound in
+                self?.glue(inbound: inbound, to: forward)
+                    ?? inbound.eventLoop.makeSucceededVoidFuture()
+            }
+
+        bootstrap.bind(host: "127.0.0.1", port: forward.localPort).whenComplete { [weak self] result in
+            guard let self else { return }
+            self.starting.remove(id)
+            switch result {
+            case .success(let serverChannel):
+                self.listeners[id] = serverChannel
+                self.closing[id] = nil
+                self.log.info("Listening on 127.0.0.1:\(forward.localPort, privacy: .public)")
+                self.emit(id, .listening)
+            case .failure(let error):
+                self.log.error("Bind failed on 127.0.0.1:\(forward.localPort, privacy: .public): \(String(describing: error), privacy: .public)")
+                self.emit(id, .failed(Self.describe(error, port: forward.localPort)))
+            }
+        }
+    }
+
+    func stop(_ id: UUID) {
+        group.next().execute { [weak self] in
+            guard let self else { return }
+            if let listener = self.listeners[id] {
+                // Record the close future so a subsequent start() waits for the
+                // socket to be fully released before re-binding the same port.
+                self.closing[id] = listener.close()
+            }
+            self.listeners[id] = nil
+            // Tear down every in-flight tunnel for this forward; closing the inbound
+            // channel cascades to its glued SSH child via GlueHandler.channelInactive.
+            self.tunnels[id]?.values.forEach { $0.close(promise: nil) }
+            self.tunnels[id] = nil
+            self.emit(id, .stopped)
+        }
+    }
+
+    /// Close all listeners and every in-flight tunnel child channel. Used on
+    /// session teardown; does NOT emit per-forward `.stopped` since the whole
+    /// session is going away.
+    /// Close every listener and in-flight tunnel; the returned future completes
+    /// only once they are all actually closed (sockets released). Callers must
+    /// await this before shutting the event-loop group down, otherwise a listener
+    /// can linger and the next session's bind fails with EADDRINUSE.
+    @discardableResult
+    func stopAll() -> EventLoopFuture<Void> {
+        let loop = group.next()
+        let promise = loop.makePromise(of: Void.self)
+        loop.execute { [weak self] in
+            guard let self else { return promise.succeed(()) }
+            var closes: [EventLoopFuture<Void>] = []
+            for ch in self.listeners.values { closes.append(ch.close().recover { _ in () }) }
+            self.listeners.removeAll()
+            for channels in self.tunnels.values {
+                for ch in channels.values { closes.append(ch.close().recover { _ in () }) }
+            }
+            self.tunnels.removeAll()
+            self.starting.removeAll()
+            self.closing.removeAll()
+            EventLoopFuture.andAllComplete(closes, on: loop).cascade(to: promise)
+        }
+        return promise.futureResult
+    }
+
+    // MARK: Glue: inbound TCP child <-> SSH directTCPIP child
+
+    private func glue(inbound: Channel, to forward: PortForward) -> EventLoopFuture<Void> {
+        guard (1...65535).contains(forward.remotePort) else {
+            inbound.close(promise: nil)
+            return inbound.eventLoop.makeFailedFuture(PortForwardError.invalidPort)
+        }
+
+        // Re-fetch the NIOSSHHandler off the parent pipeline per inbound connection.
+        // Cheap, and avoids holding a strong ref that could outlive the channel.
+        return parentChannel.pipeline.handler(type: NIOSSHHandler.self).flatMap { sshHandler in
+            guard let origin = inbound.remoteAddress else {
+                return inbound.eventLoop.makeFailedFuture(PortForwardError.noOriginator)
+            }
+
+            let promise = inbound.eventLoop.makePromise(of: Channel.self)
+            let direct = SSHChannelType.DirectTCPIP(
+                targetHost: forward.remoteHost,
+                targetPort: forward.remotePort,
+                originatorAddress: origin
+            )
+
+            sshHandler.createChannel(promise, channelType: .directTCPIP(direct)) { child, type in
+                guard case .directTCPIP = type else {
+                    return child.eventLoop.makeFailedFuture(PortForwardError.badType)
+                }
+                return child.setOption(ChannelOptions.allowRemoteHalfClosure, value: true).flatMap {
+                    // inbound and child share the single event loop (numberOfThreads == 1),
+                    // so syncOperations on both is safe here.
+                    child.eventLoop.makeCompletedFuture {
+                        let (ours, theirs) = GlueHandler.matchedPair()
+                        let cs = child.pipeline.syncOperations
+                        try cs.addHandler(SSHWrapperHandler())
+                        try cs.addHandler(ours)
+                        let isync = inbound.pipeline.syncOperations
+                        try isync.addHandler(theirs)
+                    }
+                }
+            }
+
+            return promise.futureResult.flatMap { child -> EventLoopFuture<Void> in
+                // Track this tunnel so stop(id)/stopAll() can tear it down; drop it
+                // from the set once the inbound channel closes.
+                let key = ObjectIdentifier(inbound)
+                self.tunnels[forward.id, default: [:]][key] = inbound
+                inbound.closeFuture.whenComplete { [weak self] _ in
+                    self?.tunnels[forward.id]?[key] = nil
+                }
+                // autoRead stays ON; GlueHandler pulls data continuously and gates
+                // for backpressure. No manual read kicks needed.
+                return inbound.eventLoop.makeSucceededVoidFuture()
+            }.flatMapError { err in
+                // On any failure wiring the tunnel, close the inbound TCP so the
+                // client sees a refused/closed connection.
+                inbound.close(promise: nil)
+                return inbound.eventLoop.makeFailedFuture(err)
+            }
+        }
+    }
+
+    // MARK: Helpers
+
+    private static func describe(_ error: Error, port: Int? = nil) -> String {
+        let p = port.map(String.init) ?? "?"
+        if let io = error as? IOError {
+            switch io.errnoCode {
+            case EADDRINUSE:
+                return "Local port \(p) is already in use — another app (or another forward) may have it. Pick a different local port."
+            case EACCES, EPERM:
+                return "Local port \(p) isn't allowed on iOS — use a port of 1024 or higher."
+            case EADDRNOTAVAIL:
+                return "Local address isn't available for port \(p)."
+            default:
+                return "\(io.localizedDescription) (errno \(io.errnoCode))"
+            }
+        }
+        if let channelError = error as? ChannelError {
+            return "\(channelError)"
+        }
+        return error.localizedDescription
+    }
+}

--- a/Sources/SSH/SSHSession.swift
+++ b/Sources/SSH/SSHSession.swift
@@ -13,6 +13,10 @@ struct SSHConnection: Identifiable {
     /// PEM/OpenSSH private key texts to try for public-key auth, in order.
     var privateKeys: [String] = []
     var term: String = "xterm-256color"
+    /// The owning `SavedConnection.id`, if this runtime connection came from a
+    /// saved host. Not persisted; rides along so the UI can resolve persisted
+    /// port forwards for this connection.
+    var savedID: UUID? = nil
 }
 
 /// High-level lifecycle of an SSH session, surfaced to the UI.
@@ -40,15 +44,23 @@ final class SSHSession: TerminalSession {
     private var childChannel: Channel?
     private var ptyHandler: PTYChannelHandler?
 
+    private var forwardManager: PortForwardManager?
+    private let forwards: [PortForward]
+    private let onForwardChange: ((UUID, PortForwardStatus) -> Void)?
+
     init(
         connection: SSHConnection,
         view: TerminalSurfaceView,
+        forwards: [PortForward] = [],
         onHostKeyPrompt: TOFUHostKeyDelegate.Prompt? = nil,
+        onForwardChange: ((UUID, PortForwardStatus) -> Void)? = nil,
         onStateChange: @escaping (SSHSessionState) -> Void
     ) {
         self.connection = connection
         self.view = view
+        self.forwards = forwards
         self.onHostKeyPrompt = onHostKeyPrompt
+        self.onForwardChange = onForwardChange
         self.onStateChange = onStateChange
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     }
@@ -113,12 +125,22 @@ final class SSHSession: TerminalSession {
 
     func stop() {
         let group = self.group
-        childChannel?.close(promise: nil)
-        channel?.close(promise: nil)
+        // Close port-forward listeners + tunnels FIRST and wait for them to be
+        // fully released, THEN close the channels and shut the group down. Shutting
+        // the group down concurrently can leave a listener lingering bound, so the
+        // next session's bind fails with EADDRINUSE.
+        let cleanup = forwardManager?.stopAll() ?? group.next().makeSucceededVoidFuture()
+        forwardManager = nil
+        let child = childChannel
+        let parent = channel
         childChannel = nil
         channel = nil
         ptyHandler = nil
-        group.shutdownGracefully { _ in }
+        cleanup.whenComplete { _ in
+            child?.close(promise: nil)
+            parent?.close(promise: nil)
+            group.shutdownGracefully { _ in }
+        }
     }
 
     // MARK: Open the PTY shell child channel
@@ -160,11 +182,33 @@ final class SSHSession: TerminalSession {
                         self.notify(.failed(Self.describe(error)))
                     case .success(let childChannel):
                         self.childChannel = childChannel
+                        // The parent `channel` is the authenticated connection;
+                        // the forward manager reuses it and the shared group.
+                        let mgr = PortForwardManager(
+                            parentChannel: channel,
+                            group: self.group,
+                            onChange: { [weak self] id, st in self?.onForwardChange?(id, st) }
+                        )
+                        self.forwardManager = mgr
+                        for f in self.forwards where f.autoStart { mgr.start(f) }
                         self.notify(.connected)
                     }
                 }
             }
         }
+    }
+
+    // MARK: Port forwarding
+
+    /// Start the listener for the forward with `id` (looked up in the stored
+    /// configs). The manager hops to the event loop internally.
+    func startForward(_ id: UUID) {
+        guard let f = forwards.first(where: { $0.id == id }) else { return }
+        forwardManager?.start(f)
+    }
+
+    func stopForward(_ id: UUID) {
+        forwardManager?.stop(id)
     }
 
     private func deliverOutput(_ buf: ByteBuffer) {

--- a/Sources/SSH/SSHWrapperHandler.swift
+++ b/Sources/SSH/SSHWrapperHandler.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import NIOSSH
+
+/// A simple handler that wraps data into `SSHChannelData` for forwarding, and
+/// unwraps it on the way back. Ported from the swift-nio-ssh sample's
+/// `PortForwardingServer`; the only change is using `PortForwardError.invalidData`
+/// (the sample's `SSHClientError` is internal to the example target).
+final class SSHWrapperHandler: ChannelDuplexHandler {
+    typealias InboundIn = SSHChannelData
+    typealias InboundOut = ByteBuffer
+    typealias OutboundIn = ByteBuffer
+    typealias OutboundOut = SSHChannelData
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let data = self.unwrapInboundIn(data)
+
+        guard case .channel = data.type, case .byteBuffer(let buffer) = data.data else {
+            context.fireErrorCaught(PortForwardError.invalidData)
+            return
+        }
+
+        context.fireChannelRead(self.wrapInboundOut(buffer))
+    }
+
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        let data = self.unwrapOutboundIn(data)
+        let wrapped = SSHChannelData(type: .channel, data: .byteBuffer(data))
+        context.write(self.wrapOutboundOut(wrapped), promise: promise)
+    }
+}

--- a/Sources/UI/AddConnectionView.swift
+++ b/Sources/UI/AddConnectionView.swift
@@ -5,15 +5,18 @@ import SwiftUI
 struct AddConnectionView: View {
     @ObservedObject var store: ConnectionStore
     @ObservedObject var keyStore: KeyStore
+    @ObservedObject var forwardStore: PortForwardStore
     @Environment(\.dismiss) private var dismiss
 
     @State private var connection: SavedConnection
     @State private var portText: String
     @State private var password: String
+    @State private var editingForward: PortForward?
 
-    init(store: ConnectionStore, keyStore: KeyStore, connection: SavedConnection) {
+    init(store: ConnectionStore, keyStore: KeyStore, forwardStore: PortForwardStore, connection: SavedConnection) {
         self.store = store
         self.keyStore = keyStore
+        self.forwardStore = forwardStore
         _connection = State(initialValue: connection)
         _portText = State(initialValue: String(connection.port))
         _password = State(initialValue: store.savedPassword(for: connection) ?? "")
@@ -70,6 +73,34 @@ struct AddConnectionView: View {
                     SecureField("password (optional)", text: $password)
                     Toggle("Save password", isOn: $connection.savePassword)
                 }
+
+                Section("Port Forwards") {
+                    ForEach(forwardStore.forwards(for: connection.id)) { f in
+                        Button {
+                            editingForward = f
+                        } label: {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(f.title).foregroundStyle(.primary)
+                                    Text(f.subtitle).font(.caption).foregroundStyle(.secondary)
+                                }
+                                Spacer()
+                                if f.autoStart {
+                                    Image(systemName: "bolt.fill").foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                    .onDelete { offsets in
+                        let items = forwardStore.forwards(for: connection.id)
+                        for index in offsets { forwardStore.delete(items[index]) }
+                    }
+                    Button {
+                        editingForward = PortForward(connectionID: connection.id)
+                    } label: {
+                        Label("Add Port Forward", systemImage: "plus")
+                    }
+                }
             }
             .navigationTitle(connection.host.isEmpty ? "New Connection" : "Edit Connection")
             .navigationBarTitleDisplayMode(.inline)
@@ -78,6 +109,15 @@ struct AddConnectionView: View {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") { save() }.disabled(!isValid)
                 }
+            }
+            .sheet(item: $editingForward) { f in
+                PortForwardEditView(
+                    store: forwardStore,
+                    existingPorts: forwardStore.forwards(for: connection.id)
+                        .filter { $0.id != f.id }
+                        .map { $0.localPort },
+                    forward: f
+                )
             }
         }
     }

--- a/Sources/UI/BrowserScreen.swift
+++ b/Sources/UI/BrowserScreen.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+/// Full-screen in-app browser cover wrapping a `WKWebView` (via
+/// `WebViewRepresentable`) with an address bar, reload/stop control, a linear
+/// progress indicator, and bottom-bar back/forward navigation. Opened from the
+/// port-forward status sheet to load `http://127.0.0.1:<localPort>`, which the
+/// kernel loopback hands to the NIO listener that tunnels it over SSH.
+struct BrowserScreen: View {
+    let initialURL: URL
+    let onClose: () -> Void
+
+    @StateObject private var model = WebViewModel()
+    @State private var urlText: String
+
+    init(initialURL: URL, onClose: @escaping () -> Void) {
+        self.initialURL = initialURL
+        self.onClose = onClose
+        _urlText = State(initialValue: initialURL.absoluteString)
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                topBar
+                if model.isLoading {
+                    ProgressView(value: model.progress)
+                        .progressViewStyle(.linear)
+                }
+                ZStack {
+                    WebViewRepresentable(model: model)
+                    if let error = model.lastError {
+                        ContentUnavailableView(
+                            label: {
+                                Label("Can't Open Page", systemImage: "wifi.exclamationmark")
+                            },
+                            description: { Text(error) },
+                            actions: {
+                                Button("Retry") { model.reload() }
+                            }
+                        )
+                        .background(.background)
+                    }
+                }
+            }
+            .toolbar {
+                ToolbarItemGroup(placement: .bottomBar) {
+                    Button { model.goBack() } label: {
+                        Image(systemName: "chevron.left")
+                    }
+                    .disabled(!model.canGoBack)
+                    Spacer()
+                    Button { model.goForward() } label: {
+                        Image(systemName: "chevron.right")
+                    }
+                    .disabled(!model.canGoForward)
+                }
+            }
+        }
+        .onAppear { model.load(initialURL) }
+        .onChange(of: model.url) { _, newValue in
+            if let newValue { urlText = newValue.absoluteString }
+        }
+        .preferredColorScheme(.dark)
+    }
+
+    @ViewBuilder private var topBar: some View {
+        HStack(spacing: 10) {
+            Button(action: onClose) {
+                Image(systemName: "chevron.left")
+                    .font(.body.weight(.semibold))
+            }
+            TextField("address", text: $urlText)
+                .keyboardType(.URL)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .submitLabel(.go)
+                .textFieldStyle(.roundedBorder)
+                .onSubmit {
+                    if let url = normalized(urlText) { model.load(url) }
+                }
+            Button {
+                if model.isLoading {
+                    model.stop()
+                } else {
+                    model.reload()
+                }
+            } label: {
+                Image(systemName: model.isLoading ? "xmark" : "arrow.clockwise")
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    /// If the typed string lacks a scheme, prepend `http://` before loading.
+    private func normalized(_ string: String) -> URL? {
+        let trimmed = string.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return nil }
+        if trimmed.contains("://") {
+            return URL(string: trimmed)
+        }
+        return URL(string: "http://\(trimmed)")
+    }
+}

--- a/Sources/UI/ConnectionListView.swift
+++ b/Sources/UI/ConnectionListView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct ConnectionListView: View {
     @ObservedObject var store: ConnectionStore
     @ObservedObject var keyStore: KeyStore
+    @ObservedObject var forwardStore: PortForwardStore
     let onConnect: (SSHConnection) -> Void
 
     @State private var editing: SavedConnection?
@@ -30,7 +31,10 @@ struct ConnectionListView: View {
                         }
                     }
                     .swipeActions(edge: .trailing) {
-                        Button(role: .destructive) { store.delete(conn) } label: {
+                        Button(role: .destructive) {
+                            store.delete(conn)
+                            forwardStore.deleteForwards(for: conn.id)
+                        } label: {
                             Label("Delete", systemImage: "trash")
                         }
                         Button { editing = conn } label: {
@@ -48,7 +52,7 @@ struct ConnectionListView: View {
                 }
             }
             .sheet(item: $editing) { conn in
-                AddConnectionView(store: store, keyStore: keyStore, connection: conn)
+                AddConnectionView(store: store, keyStore: keyStore, forwardStore: forwardStore, connection: conn)
             }
             .alert(
                 "Password",
@@ -77,7 +81,7 @@ struct ConnectionListView: View {
     private func makeConnection(_ conn: SavedConnection, password: String) -> SSHConnection {
         SSHConnection(
             host: conn.host, port: conn.port, username: conn.username,
-            password: password, privateKeys: keyTexts(for: conn))
+            password: password, privateKeys: keyTexts(for: conn), savedID: conn.id)
     }
 
     private func connect(_ conn: SavedConnection) {

--- a/Sources/UI/PortForwardEditView.swift
+++ b/Sources/UI/PortForwardEditView.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+/// Form sheet to add or edit a single SSH local port forward (ssh -L), mirroring
+/// the shape of `AddConnectionView`. Local-port uniqueness within a connection is
+/// enforced here (via `existingPorts`), not in the store.
+struct PortForwardEditView: View {
+    @ObservedObject var store: PortForwardStore
+    /// Local ports already used by sibling forwards on the same connection,
+    /// excluding this forward's own port.
+    let existingPorts: [Int]
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var forward: PortForward
+    @State private var localPortText: String
+    @State private var remotePortText: String
+
+    init(store: PortForwardStore, existingPorts: [Int], forward: PortForward) {
+        self.store = store
+        self.existingPorts = existingPorts
+        _forward = State(initialValue: forward)
+        _localPortText = State(initialValue: String(forward.localPort))
+        _remotePortText = State(initialValue: String(forward.remotePort))
+    }
+
+    private var isValid: Bool {
+        guard let local = Int(localPortText), (1...65535).contains(local),
+              let remote = Int(remotePortText), (1...65535).contains(remote),
+              !forward.remoteHost.trimmingCharacters(in: .whitespaces).isEmpty else {
+            return false
+        }
+        return !existingPorts.contains(local)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("General") {
+                    TextField("name (optional)", text: $forward.name)
+                    Toggle("Start on connect", isOn: $forward.autoStart)
+                }
+
+                Section {
+                    TextField("local port", text: $localPortText)
+                        .keyboardType(.numberPad)
+                } header: {
+                    Text("Local")
+                } footer: {
+                    Text("Reachable at 127.0.0.1:\(localPortText) on this device.")
+                }
+
+                Section("Remote (from the server)") {
+                    TextField("remote host", text: $forward.remoteHost)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                    TextField("remote port", text: $remotePortText)
+                        .keyboardType(.numberPad)
+                    Picker("Scheme", selection: $forward.scheme) {
+                        Text("http").tag("http")
+                        Text("https").tag("https")
+                    }
+                }
+            }
+            .navigationTitle(forward.name.isEmpty ? "New Forward" : "Edit Forward")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { save() }.disabled(!isValid)
+                }
+            }
+        }
+    }
+
+    private func save() {
+        forward.remoteHost = forward.remoteHost.trimmingCharacters(in: .whitespaces)
+        forward.localPort = Int(localPortText) ?? forward.localPort
+        forward.remotePort = Int(remotePortText) ?? forward.remotePort
+        store.save(forward)
+        dismiss()
+    }
+}

--- a/Sources/UI/PortForwardStatusSheet.swift
+++ b/Sources/UI/PortForwardStatusSheet.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+/// Live management sheet opened from the terminal status bar: lists every port
+/// forward configured for the active connection, shows its runtime status, lets
+/// the user toggle each listener on/off, and opens an in-app browser for web
+/// forwards that are currently listening.
+struct PortForwardStatusSheet: View {
+    /// This connection's persisted forward configs.
+    let forwards: [PortForward]
+    /// Live runtime status keyed by forward id.
+    let statuses: [UUID: PortForwardStatus]
+    let onToggle: (PortForward, Bool) -> Void
+    let onOpenBrowser: (PortForward) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if forwards.isEmpty {
+                    ContentUnavailableView(
+                        "No Port Forwards",
+                        systemImage: "network",
+                        description: Text("Add forwards in the host's settings.")
+                    )
+                }
+                ForEach(forwards) { forward in
+                    row(for: forward)
+                }
+            }
+            .navigationTitle("Port Forwards")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) { Button("Done") { dismiss() } }
+            }
+        }
+        .preferredColorScheme(.dark)
+    }
+
+    @ViewBuilder private func row(for forward: PortForward) -> some View {
+        let status = statuses[forward.id] ?? .stopped
+        HStack(spacing: 12) {
+            statusDot(status)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(forward.title)
+                Text(forward.subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                if case .failed(let message) = status {
+                    Text(message)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            Spacer()
+            if forward.isWeb, case .listening = status {
+                Button {
+                    onOpenBrowser(forward)
+                } label: {
+                    Image(systemName: "globe")
+                }
+                .buttonStyle(.borderless)
+            }
+            Toggle("", isOn: Binding(
+                get: { if case .listening = status { return true } else { return false } },
+                set: { onToggle(forward, $0) }
+            ))
+            .labelsHidden()
+        }
+    }
+
+    @ViewBuilder private func statusDot(_ status: PortForwardStatus) -> some View {
+        switch status {
+        case .stopped:
+            Circle().fill(.gray).frame(width: 10, height: 10)
+        case .starting:
+            ProgressView().controlSize(.small)
+        case .listening:
+            Circle().fill(.green).frame(width: 10, height: 10)
+        case .failed:
+            Circle().fill(.red).frame(width: 10, height: 10)
+        }
+    }
+}

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -4,11 +4,12 @@ struct RootView: View {
     @EnvironmentObject private var ghostty: Ghostty.App
     @StateObject private var connections = ConnectionStore()
     @StateObject private var keys = KeyStore()
+    @StateObject private var forwards = PortForwardStore()
     @State private var activeConnection: SSHConnection?
 
     var body: some View {
         TabView {
-            ConnectionListView(store: connections, keyStore: keys) { connection in
+            ConnectionListView(store: connections, keyStore: keys, forwardStore: forwards) { connection in
                 activeConnection = connection
             }
             .tabItem { Label("Hosts", systemImage: "server.rack") }
@@ -20,7 +21,11 @@ struct RootView: View {
                 .tabItem { Label("AI", systemImage: "sparkles") }
         }
         .fullScreenCover(item: $activeConnection) { connection in
-            TerminalScreen(connection: connection) {
+            TerminalScreen(
+                connection: connection,
+                savedConnectionID: connection.savedID,
+                forwardStore: forwards
+            ) {
                 activeConnection = nil
             }
             .environmentObject(ghostty)

--- a/Sources/UI/TerminalScreen.swift
+++ b/Sources/UI/TerminalScreen.swift
@@ -7,17 +7,38 @@ struct HostKeyPromptRequest {
     let decide: (Bool) -> Void
 }
 
+/// A URL tapped in the terminal. Wraps `URL` so it can drive a `fullScreenCover(item:)`.
+struct TappedURL: Identifiable {
+    let id = UUID()
+    let url: URL
+}
+
 /// Full-screen terminal for an active SSH connection, with a slim status bar
 /// and a close button.
 struct TerminalScreen: View {
     @EnvironmentObject private var ghostty: Ghostty.App
     let connection: SSHConnection
+    /// The owning `SavedConnection.id`, used to resolve persisted port forwards.
+    let savedConnectionID: UUID?
+    @ObservedObject var forwardStore: PortForwardStore
     let onClose: () -> Void
 
     @State private var state: SSHSessionState = .idle
     @State private var hostKeyRequest: HostKeyPromptRequest?
     @State private var terminalView: TerminalSurfaceView?
     @State private var showingAICommands = false
+    @State private var showingForwards = false
+    @State private var forwardStates: [UUID: PortForwardStatus] = [:]
+    @State private var session: SSHSession?
+    @State private var browsing: PortForward?
+    /// A URL tapped in the terminal, opened in the in-app browser.
+    @State private var linkURL: TappedURL?
+
+    /// Persisted forward configs for this connection (empty if not a saved host).
+    private var connectionForwards: [PortForward] {
+        guard let id = savedConnectionID else { return [] }
+        return forwardStore.forwards(for: id)
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -26,14 +47,19 @@ struct TerminalScreen: View {
                 SSHSession(
                     connection: connection,
                     view: view,
+                    forwards: connectionForwards,
                     onHostKeyPrompt: { prompt, decide in
                         hostKeyRequest = HostKeyPromptRequest(prompt: prompt, decide: decide)
-                    }
+                    },
+                    onForwardChange: { id, st in forwardStates[id] = st }
                 ) { newState in
                     state = newState
                 }
             }, onCreate: { view in
+                view.onOpenURL = { url in linkURL = TappedURL(url: url) }
                 DispatchQueue.main.async { terminalView = view }
+            }, onSession: { s in
+                DispatchQueue.main.async { session = s }
             })
         }
         .sheet(isPresented: $showingAICommands) {
@@ -43,6 +69,27 @@ struct TerminalScreen: View {
                     (terminalView?.readVisibleText() ?? "", CommandHistory.shared.recent(limit: 15))
                 }
             )
+        }
+        .sheet(isPresented: $showingForwards) {
+            PortForwardStatusSheet(
+                forwards: connectionForwards,
+                statuses: forwardStates,
+                onToggle: { f, on in
+                    if on { session?.startForward(f.id) } else { session?.stopForward(f.id) }
+                },
+                onOpenBrowser: { f in
+                    showingForwards = false
+                    browsing = f
+                }
+            )
+        }
+        .fullScreenCover(item: $browsing) { f in
+            if let url = f.localURL {
+                BrowserScreen(initialURL: url) { browsing = nil }
+            }
+        }
+        .fullScreenCover(item: $linkURL) { tapped in
+            BrowserScreen(initialURL: tapped.url) { linkURL = nil }
         }
         .background(Color.black.ignoresSafeArea())
         .preferredColorScheme(.dark)
@@ -109,6 +156,11 @@ struct TerminalScreen: View {
                 Image(systemName: "sparkles").font(.body.weight(.semibold))
             }
             .accessibilityLabel("AI commands")
+            Button { showingForwards = true } label: {
+                Image(systemName: "network").font(.body.weight(.semibold))
+            }
+            .accessibilityLabel("Port forwards")
+            .disabled(state != .connected)
             statusIndicator
         }
         .padding(.horizontal, 14)

--- a/Sources/UI/TerminalView.swift
+++ b/Sources/UI/TerminalView.swift
@@ -9,6 +9,9 @@ struct TerminalView: UIViewRepresentable {
     /// Called once with the created surface view so the hosting screen can drive
     /// it (e.g. the AI command assistant typing a command into the terminal).
     var onCreate: ((TerminalSurfaceView) -> Void)? = nil
+    /// Called in `makeUIView` with the freshly made session, when it is an
+    /// `SSHSession`, so the hosting screen can drive port forwards.
+    var onSession: ((SSHSession) -> Void)? = nil
 
     func makeUIView(context: Context) -> TerminalSurfaceView {
         let view = TerminalSurfaceView(ghostty: ghostty)
@@ -16,6 +19,7 @@ struct TerminalView: UIViewRepresentable {
         view.delegate = session
         context.coordinator.session = session
         session.start()
+        if let ssh = session as? SSHSession { onSession?(ssh) }
         onCreate?(view)
         return view
     }

--- a/project.yml
+++ b/project.yml
@@ -67,6 +67,10 @@ targets:
           - UIInterfaceOrientationLandscapeRight
         # SSH needs to reach hosts on the local network too.
         NSLocalNetworkUsageDescription: gterm connects to SSH servers, which may be on your local network.
+        # Allow cleartext http to loopback/link-local/.local so the in-app browser
+        # can load http://127.0.0.1:<port> served by a tunneled port forward.
+        NSAppTransportSecurity:
+          NSAllowsLocalNetworking: true
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: io.github.madeye.gterm


### PR DESCRIPTION
Adds SSH **local port forwarding**, an **in-app browser**, and **tap-to-open URLs** in the terminal.

## Features
- **Port forwarding** — `swift-nio-ssh` direct-tcpip channels glued to a `127.0.0.1` listener (upstream `GlueHandler` + an `SSHChannelData` wrapper). Per-connection forwards: add/list/toggle with live status.
- **In-app browser** — a WKWebView screen with an address bar; opens a forwarded port (`http://127.0.0.1:<localPort>`) or any tapped URL.
- **Tap-to-open URLs** — tapping a link in the terminal synthesizes a ⌘-modified click (the modifier libghostty needs to follow auto-detected URLs / OSC 8 hyperlinks); the `OPEN_URL` action routes it to the browser.

## Verified
End-to-end against a docker SSH host (Colima VM): `curl` through a forward returned **HTTP 200**. `gtermTests` 45/45 pass.

## Robustness fixes (found via the E2E test)
- `autoRead` left **ON** so `GlueHandler`'s read-gating actually pumps data (turning it off stalled the tunnel).
- Guard duplicate/racing `start()`; sequence a re-bind after the prior listener closes — no `EADDRINUSE` on off→on toggles.
- `stop()` awaits `stopAll()` (listeners/tunnels fully closed) before the event-loop group shuts down — reconnects don't collide on the port.
- Clear, wrapping bind-error messages (port-in-use / privileged port).
- ATS `NSAllowsLocalNetworking` so the browser can load `http://127.0.0.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)