### PR TITLE
Get Started guide, Settings tab, and terminal color themes

### DIFF
--- a/Sources/Ghostty/GhosttyApp.swift
+++ b/Sources/Ghostty/GhosttyApp.swift
@@ -9,7 +9,7 @@ extension Ghostty {
     /// startup; the app is created with the runtime callbacks libghostty uses
     /// to talk back to us (wakeup, actions, clipboard).
     final class App: ObservableObject {
-        let config: Config
+        private(set) var config: Config
         private(set) var app: ghostty_app_t?
         private var displayLink: CADisplayLink?
 
@@ -53,6 +53,15 @@ extension Ghostty {
         func tick() {
             guard let app else { return }
             ghostty_app_tick(app)
+        }
+
+        /// Rebuild the config (picking up the current terminal theme) and apply it
+        /// so newly opened sessions use it. Call after changing the theme.
+        func reloadConfig() {
+            guard let app else { return }
+            let newConfig = Config()
+            ghostty_app_update_config(app, newConfig.c)
+            config = newConfig
         }
 
         /// Drive `ghostty_app_tick` once per display refresh so animations

--- a/Sources/Ghostty/GhosttyConfig.swift
+++ b/Sources/Ghostty/GhosttyConfig.swift
@@ -14,9 +14,26 @@ extension Ghostty {
             }
             self.c = cfg
 
-            // We have no config file on iOS; just finalize the defaults so the
-            // values are usable.
+            // Apply the user-selected terminal color theme (if not the default)
+            // by writing its colors to a config file and loading it.
+            Self.applyTheme(to: cfg)
+
             ghostty_config_finalize(cfg)
+        }
+
+        /// Write the selected theme's colors to a temp config file and load it.
+        /// No-op for the default theme (keeps ghostty's compiled-in colors).
+        private static func applyTheme(to cfg: ghostty_config_t) {
+            let text = TerminalTheme.selected.configText
+            guard !text.isEmpty else { return }
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent("gterm-theme.conf")
+            do {
+                try text.write(to: url, atomically: true, encoding: .utf8)
+                url.path.withCString { ghostty_config_load_file(cfg, $0) }
+            } catch {
+                Ghostty.logger.error("failed to write theme config: \(String(describing: error), privacy: .public)")
+            }
         }
 
         deinit {

--- a/Sources/Ghostty/TerminalTheme.swift
+++ b/Sources/Ghostty/TerminalTheme.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// A terminal color theme: background, foreground, and a 16-color ANSI palette.
+/// Applied to the ghostty surface by writing a config file consumed via
+/// `ghostty_config_load_file`. The "default" theme leaves ghostty's built-in
+/// colors untouched (its colors here are only used to draw the Settings preview).
+struct TerminalTheme: Identifiable, Equatable {
+    let id: String
+    let name: String
+    let background: String
+    let foreground: String
+    /// 16 hex colors (#rrggbb): ANSI 0–7 then bright 8–15.
+    let palette: [String]
+
+    /// The default theme keeps ghostty's compiled-in colors (no override).
+    var overridesColors: Bool { id != "default" }
+
+    /// ghostty config-file text for this theme; empty for the default.
+    var configText: String {
+        guard overridesColors else { return "" }
+        var lines = ["background = \(background)", "foreground = \(foreground)"]
+        for (i, color) in palette.enumerated() {
+            lines.append("palette = \(i)=\(color)")
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    // MARK: Selection (persisted)
+
+    private static let defaultsKey = "terminalTheme"
+
+    static var selectedID: String {
+        get { UserDefaults.standard.string(forKey: defaultsKey) ?? "default" }
+        set { UserDefaults.standard.set(newValue, forKey: defaultsKey) }
+    }
+
+    static var selected: TerminalTheme { theme(id: selectedID) }
+
+    static func theme(id: String) -> TerminalTheme {
+        all.first { $0.id == id } ?? all[0]
+    }
+
+    // MARK: Built-in themes
+
+    static let all: [TerminalTheme] = [
+        TerminalTheme(id: "default", name: "Ghostty Default",
+                      background: "#1d1f21", foreground: "#c5c8c6",
+                      palette: ["#1d1f21", "#cc6666", "#b5bd68", "#f0c674", "#81a2be", "#b294bb", "#8abeb7", "#c5c8c6",
+                                "#969896", "#cc6666", "#b5bd68", "#f0c674", "#81a2be", "#b294bb", "#8abeb7", "#ffffff"]),
+        TerminalTheme(id: "dracula", name: "Dracula",
+                      background: "#282a36", foreground: "#f8f8f2",
+                      palette: ["#21222c", "#ff5555", "#50fa7b", "#f1fa8c", "#bd93f9", "#ff79c6", "#8be9fd", "#f8f8f2",
+                                "#6272a4", "#ff6e6e", "#69ff94", "#ffffa5", "#d6acff", "#ff92df", "#a4ffff", "#ffffff"]),
+        TerminalTheme(id: "nord", name: "Nord",
+                      background: "#2e3440", foreground: "#d8dee9",
+                      palette: ["#3b4252", "#bf616a", "#a3be8c", "#ebcb8b", "#81a1c1", "#b48ead", "#88c0d0", "#e5e9f0",
+                                "#4c566a", "#bf616a", "#a3be8c", "#ebcb8b", "#81a1c1", "#b48ead", "#8fbcbb", "#eceff4"]),
+        TerminalTheme(id: "solarized-dark", name: "Solarized Dark",
+                      background: "#002b36", foreground: "#839496",
+                      palette: ["#073642", "#dc322f", "#859900", "#b58900", "#268bd2", "#d33682", "#2aa198", "#eee8d5",
+                                "#002b36", "#cb4b16", "#586e75", "#657b83", "#839496", "#6c71c4", "#93a1a1", "#fdf6e3"]),
+        TerminalTheme(id: "gruvbox-dark", name: "Gruvbox Dark",
+                      background: "#282828", foreground: "#ebdbb2",
+                      palette: ["#282828", "#cc241d", "#98971a", "#d79921", "#458588", "#b16286", "#689d6a", "#a89984",
+                                "#928374", "#fb4934", "#b8bb26", "#fabd2f", "#83a598", "#d3869b", "#8ec07c", "#ebdbb2"]),
+        TerminalTheme(id: "catppuccin-mocha", name: "Catppuccin Mocha",
+                      background: "#1e1e2e", foreground: "#cdd6f4",
+                      palette: ["#45475a", "#f38ba8", "#a6e3a1", "#f9e2af", "#89b4fa", "#f5c2e7", "#94e2d5", "#bac2de",
+                                "#585b70", "#f38ba8", "#a6e3a1", "#f9e2af", "#89b4fa", "#f5c2e7", "#94e2d5", "#a6adc8"]),
+    ]
+}

--- a/Sources/UI/OnboardingView.swift
+++ b/Sources/UI/OnboardingView.swift
@@ -1,0 +1,159 @@
+import SwiftUI
+
+/// First-launch step-by-step "Get Started" guide to gterm's core functions.
+/// Also reachable from the Settings tab. Calls `onDone` when finished or skipped.
+/// Modeled on the runse guide (step dots, per-step page, Back/Next, Start).
+struct OnboardingView: View {
+    let onDone: () -> Void
+    @State private var currentStep = 0
+
+    private let steps = GuideStep.steps
+    private var step: GuideStep { steps[currentStep] }
+    private var isLastStep: Bool { currentStep == steps.count - 1 }
+    private let accent = Color(red: 0.18, green: 0.80, blue: 0.89)
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                HStack(spacing: 8) {
+                    ForEach(steps.indices, id: \.self) { index in
+                        Capsule()
+                            .fill(index == currentStep ? accent : Color.secondary.opacity(0.25))
+                            .frame(width: index == currentStep ? 26 : 8, height: 8)
+                    }
+                }
+                .padding(.top, 18)
+                .accessibilityLabel("Step \(currentStep + 1) of \(steps.count)")
+
+                GuideStepPageView(step: step, stepNumber: currentStep + 1, stepCount: steps.count, accent: accent)
+                    .id(currentStep)
+                    .transition(.opacity)
+                    .animation(.easeInOut(duration: 0.18), value: currentStep)
+
+                Spacer(minLength: 0)
+            }
+            .navigationTitle("gterm")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done", action: onDone).fontWeight(.semibold)
+                }
+            }
+            .safeAreaInset(edge: .bottom) {
+                HStack(spacing: 12) {
+                    Button {
+                        withAnimation { currentStep = max(0, currentStep - 1) }
+                    } label: {
+                        Label("Back", systemImage: "chevron.left").frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(currentStep == 0)
+
+                    Button {
+                        if isLastStep {
+                            onDone()
+                        } else {
+                            withAnimation { currentStep += 1 }
+                        }
+                    } label: {
+                        Label(isLastStep ? "Start" : "Next", systemImage: isLastStep ? "checkmark" : "chevron.right")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .padding()
+                .background(.bar)
+            }
+        }
+    }
+}
+
+private struct GuideStep {
+    let title: String
+    let detail: String
+    let systemImage: String
+    let example: String
+
+    static let steps: [GuideStep] = [
+        GuideStep(
+            title: "Add a host",
+            detail: "Open the Hosts tab and tap + to add an SSH server — host, port, and username. Save the password to the Keychain, or leave it blank to be asked each time.",
+            systemImage: "server.rack",
+            example: "gterm connects straight to your servers over SSH — nothing routes through a third party."
+        ),
+        GuideStep(
+            title: "Bring your keys",
+            detail: "In the Keys tab, import an Ed25519 or ECDSA private key from a file or pasted text. Then pick which keys a host should try for public-key auth.",
+            systemImage: "key.fill",
+            example: "Keys are stored in the device Keychain — device-only, never synced to iCloud."
+        ),
+        GuideStep(
+            title: "A real terminal",
+            detail: "Tap a host to connect. You get Ghostty's GPU-rendered terminal with full xterm/VT emulation, plus an accessory bar for the keys iOS forgets: Esc, Ctrl, Alt, Tab, arrows.",
+            systemImage: "apple.terminal.fill",
+            example: "Pinch to resize the font, swipe with one finger to scroll, and press-and-hold to select & copy."
+        ),
+        GuideStep(
+            title: "Ask the AI",
+            detail: "Tap the sparkles button in a session and describe what you want. The AI proposes a command and shows it for review before it runs. Configure your provider in the AI tab.",
+            systemImage: "sparkles",
+            example: "Bring your own API key — it's stored masked in the Keychain and sent only to the provider you choose."
+        ),
+        GuideStep(
+            title: "Forward ports & browse",
+            detail: "Forward a local port over SSH to a service on (or reachable from) your server, then open it in the built-in browser. Tap a URL in the terminal to open it there too.",
+            systemImage: "arrow.left.arrow.right",
+            example: "Handy for a web dashboard or dev server running on a remote box."
+        ),
+        GuideStep(
+            title: "Make it yours",
+            detail: "Open the Settings tab to revisit this guide anytime, check the app version, or read the privacy policy.",
+            systemImage: "gearshape",
+            example: "You can reopen this guide later from Settings → Get Started Guide."
+        ),
+    ]
+}
+
+private struct GuideStepPageView: View {
+    let step: GuideStep
+    let stepNumber: Int
+    let stepCount: Int
+    let accent: Color
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 22) {
+                ZStack {
+                    Circle().fill(accent.opacity(0.14))
+                    Image(systemName: step.systemImage)
+                        .font(.system(size: 42, weight: .semibold))
+                        .foregroundStyle(accent)
+                }
+                .frame(width: 92, height: 92)
+                .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Step \(stepNumber) of \(stepCount)")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(accent)
+                    Text(step.title)
+                        .font(.largeTitle.bold())
+                    Text(step.detail)
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Text(step.example)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .padding(14)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.secondary.opacity(0.10), in: RoundedRectangle(cornerRadius: 8))
+            }
+            .padding(24)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -7,6 +7,10 @@ struct RootView: View {
     @StateObject private var forwards = PortForwardStore()
     @State private var activeConnection: SSHConnection?
 
+    /// Whether the user has seen the Get Started screen (persisted).
+    @AppStorage("hasSeenWelcome") private var hasSeenWelcome = false
+    @State private var showWelcome = false
+
     var body: some View {
         TabView {
             ConnectionListView(store: connections, keyStore: keys, forwardStore: forwards) { connection in
@@ -19,6 +23,9 @@ struct RootView: View {
 
             AISettingsView()
                 .tabItem { Label("AI", systemImage: "sparkles") }
+
+            SettingsView(showWelcome: $showWelcome)
+                .tabItem { Label("Settings", systemImage: "gearshape") }
         }
         .fullScreenCover(item: $activeConnection) { connection in
             TerminalScreen(
@@ -29,6 +36,15 @@ struct RootView: View {
                 activeConnection = nil
             }
             .environmentObject(ghostty)
+        }
+        .fullScreenCover(isPresented: $showWelcome) {
+            OnboardingView {
+                showWelcome = false
+                hasSeenWelcome = true
+            }
+        }
+        .onAppear {
+            if !hasSeenWelcome { showWelcome = true }
         }
     }
 }

--- a/Sources/UI/SettingsView.swift
+++ b/Sources/UI/SettingsView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+/// The "Settings" tab: re-open the Get Started guide and show app info / links.
+struct SettingsView: View {
+    /// Set to true to (re-)present the Get Started screen, handled by RootView.
+    @Binding var showWelcome: Bool
+
+    @Environment(\.openURL) private var openURL
+    /// Easter egg: three taps on the version row open the author's page.
+    @State private var versionTaps = 0
+    /// Drives the inline preview of the current terminal theme.
+    @AppStorage("terminalTheme") private var themeID = "default"
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Terminal") {
+                    NavigationLink {
+                        ThemePickerView()
+                    } label: {
+                        LabeledContent("Color Theme") {
+                            HStack(spacing: 8) {
+                                Text(TerminalTheme.theme(id: themeID).name)
+                                    .foregroundStyle(.secondary)
+                                ThemeSwatch(theme: TerminalTheme.theme(id: themeID))
+                            }
+                        }
+                    }
+                }
+
+                Section("Help") {
+                    Button {
+                        showWelcome = true
+                    } label: {
+                        Label("Get Started Guide", systemImage: "sparkles")
+                    }
+                }
+
+                Section("About") {
+                    LabeledContent("Version", value: Self.versionString)
+                        .contentShape(Rectangle())
+                        .onTapGesture { registerVersionTap() }
+                    Link(destination: URL(string: "https://github.com/madeye/gterm")!) {
+                        Label("Source on GitHub", systemImage: "chevron.left.forwardslash.chevron.right")
+                    }
+                    Link(destination: URL(string: "https://madeye.github.io/gterm/privacy/")!) {
+                        Label("Privacy Policy", systemImage: "hand.raised")
+                    }
+                }
+            }
+            .navigationTitle("Settings")
+        }
+    }
+
+    /// Count taps on the version row; every third opens the author's GitHub or
+    /// X/Twitter page at random.
+    private func registerVersionTap() {
+        versionTaps += 1
+        guard versionTaps >= 3 else { return }
+        versionTaps = 0
+        let links = [
+            URL(string: "https://github.com/madeye")!,
+            URL(string: "https://x.com/m0d8ye")!,
+        ]
+        openURL(links.randomElement()!)
+    }
+
+    private static var versionString: String {
+        let info = Bundle.main.infoDictionary
+        let v = info?["CFBundleShortVersionString"] as? String ?? "?"
+        let b = info?["CFBundleVersion"] as? String ?? "?"
+        return "\(v) (\(b))"
+    }
+}

--- a/Sources/UI/ThemePickerView.swift
+++ b/Sources/UI/ThemePickerView.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+extension Color {
+    /// Build a Color from a `#rrggbb` (or `rrggbb`) hex string.
+    init(hex: String) {
+        let s = hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
+        var v: UInt64 = 0
+        Scanner(string: s).scanHexInt64(&v)
+        self = Color(
+            red: Double((v >> 16) & 0xff) / 255.0,
+            green: Double((v >> 8) & 0xff) / 255.0,
+            blue: Double(v & 0xff) / 255.0
+        )
+    }
+}
+
+/// A live mini-terminal preview of a theme: a sample prompt + ANSI swatches on
+/// the theme's background.
+struct ThemePreview: View {
+    let theme: TerminalTheme
+
+    var body: some View {
+        let fg = Color(hex: theme.foreground)
+        VStack(alignment: .leading, spacing: 6) {
+            (Text("dev").foregroundStyle(Color(hex: theme.palette[2]))
+                + Text("@host").foregroundStyle(fg)
+                + Text(":~$ ").foregroundStyle(Color(hex: theme.palette[4]))
+                + Text("ls").foregroundStyle(fg))
+                .font(.system(size: 12, design: .monospaced))
+            HStack(spacing: 5) {
+                ForEach(1..<7, id: \.self) { i in
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(Color(hex: theme.palette[i]))
+                        .frame(width: 16, height: 9)
+                }
+            }
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(hex: theme.background), in: RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+/// A tiny inline swatch (background + a few ANSI dots) for the Settings row.
+struct ThemeSwatch: View {
+    let theme: TerminalTheme
+    var body: some View {
+        HStack(spacing: 3) {
+            ForEach([1, 2, 4, 5], id: \.self) { i in
+                Circle().fill(Color(hex: theme.palette[i])).frame(width: 8, height: 8)
+            }
+        }
+        .padding(.horizontal, 7)
+        .padding(.vertical, 6)
+        .background(Color(hex: theme.background), in: RoundedRectangle(cornerRadius: 6))
+    }
+}
+
+/// Lists the terminal color themes with a preview each; selecting one applies it
+/// to newly opened sessions.
+struct ThemePickerView: View {
+    @EnvironmentObject private var ghostty: Ghostty.App
+    @AppStorage("terminalTheme") private var selectedID = "default"
+
+    var body: some View {
+        List {
+            Section {
+                ForEach(TerminalTheme.all) { theme in
+                    Button {
+                        selectedID = theme.id
+                        ghostty.reloadConfig()
+                    } label: {
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack {
+                                Text(theme.name).foregroundStyle(.primary)
+                                Spacer()
+                                if theme.id == selectedID {
+                                    Image(systemName: "checkmark").foregroundStyle(.tint)
+                                }
+                            }
+                            ThemePreview(theme: theme)
+                        }
+                        .padding(.vertical, 4)
+                    }
+                }
+            } footer: {
+                Text("Applies to terminal sessions you open after changing it.")
+            }
+        }
+        .navigationTitle("Terminal Theme")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}


### PR DESCRIPTION
## Get Started guide
A step-by-step onboarding guide (modeled on `../runse`): step-indicator dots, a per-step page (icon, title, detail, example tip), Back/Next, and **Start** on the last step. Six steps cover the core flow (add a host → keys → terminal → AI → port forwarding/browser → settings). Shown automatically on first launch (`@AppStorage("hasSeenWelcome")`) and re-openable from Settings.

## Settings tab (new)
- **Get Started Guide** — re-open the onboarding.
- **Color Theme** — terminal theme picker (below).
- **About** — version + GitHub/Privacy links. Easter egg: tapping the version row three times opens the author's GitHub or X profile at random.

## Terminal color themes
Picker with a **live mini-terminal preview** per theme — Ghostty Default, Dracula, Nord, Solarized Dark, Gruvbox Dark, Catppuccin Mocha. The selected theme's `background`/`foreground`/16-color `palette` are written to a ghostty config file and loaded via `ghostty_config_load_file`, then applied with `ghostty_app_update_config` so sessions opened afterward use it. "Default" leaves ghostty's built-in colors untouched.

`gtermTests` 45/45 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)