### PR TITLE
AltStore: real release URL + SideStore parity in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An iOS terminal app that renders with [ghostty](../ghostty)'s `libghostty`
 engine (GPU/Metal, full xterm/VT emulation) and connects over **SSH**.
 
 > 📲 **Try the beta:** [Join on TestFlight](https://testflight.apple.com/join/qDNYS7fd) (iOS 17+, requires Apple's TestFlight app).
-> Or sideload via [AltStore / SideStore](https://madeye.github.io/gterm/altstore/) — source URL `https://madeye.github.io/gterm/altstore.json`.
+> Or sideload with [**AltStore** or **SideStore**](https://madeye.github.io/gterm/altstore/) — both read the same source URL `https://madeye.github.io/gterm/altstore.json`.
 
 iOS can't `fork`/`exec` a local shell, so gterm drives the terminal from an SSH
 connection via a custom **passthru IO backend** added to libghostty. See

--- a/docs/altstore.json
+++ b/docs/altstore.json
@@ -6,7 +6,9 @@
   "iconURL": "https://madeye.github.io/gterm/assets/icon.png",
   "website": "https://madeye.github.io/gterm/",
   "tintColor": "2ECBE3",
-  "featuredApps": ["io.github.madeye.gterm"],
+  "featuredApps": [
+    "io.github.madeye.gterm"
+  ],
   "apps": [
     {
       "name": "gterm",
@@ -14,37 +16,57 @@
       "developerName": "Max Lv",
       "subtitle": "A Ghostty terminal, over SSH",
       "localizedDescription": "gterm is a real terminal for iOS. It renders with Ghostty's GPU engine for true xterm/VT emulation, connects straight to your servers over SSH, keeps your keys on device, and ships an AI command assistant that writes the commands for you.\n\nGPU-RENDERED TERMINAL\nReal xterm/VT emulation via Ghostty's libghostty, drawn on Metal.\n\nSSH-NATIVE\nConnects with swift-nio-ssh — password and public-key auth, a PTY shell, live window resizing, and trust-on-first-use host-key verification.\n\nKEYS STAY ON DEVICE\nImport Ed25519 / ECDSA private keys into the iOS Keychain — device-only, never synced.\n\nSHELL-GRADE KEYBOARD\nA custom accessory keyboard with the keys iOS forgets — Esc, Ctrl, Alt, Tab, arrows, and sticky modifiers.\n\nAI COMMAND ASSISTANT\nDescribe what you want in plain English. The AI proposes a command and shows it for review before it runs.\n\nPORT FORWARDING & BROWSER\nForward a local port over SSH to a service on your server and open it in the built-in browser. Tap a URL in the terminal to open it there too.\n\nOpen source: https://github.com/madeye/gterm",
-    "iconURL": "https://madeye.github.io/gterm/assets/icon.png",
-    "tintColor": "2ECBE3",
-    "category": "developer",
-    "screenshots": [
-      { "imageURL": "https://madeye.github.io/gterm/altstore/01_terminal.png", "width": 1206, "height": 2622 },
-      { "imageURL": "https://madeye.github.io/gterm/altstore/02_hosts.png",    "width": 1206, "height": 2622 },
-      { "imageURL": "https://madeye.github.io/gterm/altstore/03_keys.png",     "width": 1206, "height": 2622 },
-      { "imageURL": "https://madeye.github.io/gterm/altstore/04_aicommands.png","width": 1206, "height": 2622 },
-      { "imageURL": "https://madeye.github.io/gterm/altstore/05_ai.png",       "width": 1206, "height": 2622 }
-    ],
-    "versions": [
-      {
-        "version": "1.1",
-        "buildVersion": "2026060109",
-        "marketingVersion": "1.1",
-        "date": "2026-06-01T01:23:39Z",
-        "localizedDescription": "What's new in 1.1\n\n- Get Started guide on first launch (reopen anytime from the Settings tab).\n- Settings tab with terminal color themes — Dracula, Nord, Solarized Dark, Gruvbox Dark, Catppuccin Mocha, or the default.\n- SSH port forwarding with a built-in browser.\n- Tap a URL in the terminal to open it in the browser.\n- Pinch to resize the terminal; one-finger swipe to scroll; press-and-hold to select & copy.\n- AI command assistant: a sparkles button in a session proposes a command, you review before it runs.",
-        "downloadURL": "https://github.com/madeye/gterm/releases/download/v1.1-2026060109/gterm-1.1-2026060109.ipa",
-        "size": 0,
-        "sha256": "",
-        "minOSVersion": "17.0"
-      }
-    ],
-    "appPermissions": {
-      "entitlements": [
-        "keychain-access-groups"
+      "iconURL": "https://madeye.github.io/gterm/assets/icon.png",
+      "tintColor": "2ECBE3",
+      "category": "developer",
+      "screenshots": [
+        {
+          "imageURL": "https://madeye.github.io/gterm/altstore/01_terminal.png",
+          "width": 1206,
+          "height": 2622
+        },
+        {
+          "imageURL": "https://madeye.github.io/gterm/altstore/02_hosts.png",
+          "width": 1206,
+          "height": 2622
+        },
+        {
+          "imageURL": "https://madeye.github.io/gterm/altstore/03_keys.png",
+          "width": 1206,
+          "height": 2622
+        },
+        {
+          "imageURL": "https://madeye.github.io/gterm/altstore/04_aicommands.png",
+          "width": 1206,
+          "height": 2622
+        },
+        {
+          "imageURL": "https://madeye.github.io/gterm/altstore/05_ai.png",
+          "width": 1206,
+          "height": 2622
+        }
       ],
-      "privacy": {
-        "NSLocalNetworkUsageDescription": "gterm connects to SSH servers, which may be on your local network."
+      "versions": [
+        {
+          "version": "1.1",
+          "buildVersion": "2026060109",
+          "marketingVersion": "1.1",
+          "date": "2026-06-01T01:23:39Z",
+          "localizedDescription": "What's new in 1.1\n\n- Get Started guide on first launch (reopen anytime from the Settings tab).\n- Settings tab with terminal color themes — Dracula, Nord, Solarized Dark, Gruvbox Dark, Catppuccin Mocha, or the default.\n- SSH port forwarding with a built-in browser.\n- Tap a URL in the terminal to open it in the browser.\n- Pinch to resize the terminal; one-finger swipe to scroll; press-and-hold to select & copy.\n- AI command assistant: a sparkles button in a session proposes a command, you review before it runs.",
+          "downloadURL": "https://github.com/madeye/gterm/releases/download/v1.1-2026060109/gterm-1.1-2026060109.ipa",
+          "size": 18147048,
+          "sha256": "89a3a86eea0aa3b74f7b1c3a8f6b67da7555bbb91b6aedbdef5c7ba669717f5c",
+          "minOSVersion": "17.0"
+        }
+      ],
+      "appPermissions": {
+        "entitlements": [
+          "keychain-access-groups"
+        ],
+        "privacy": {
+          "NSLocalNetworkUsageDescription": "gterm connects to SSH servers, which may be on your local network."
+        }
       }
     }
-  }
   ]
 }

--- a/docs/altstore/index.html
+++ b/docs/altstore/index.html
@@ -90,15 +90,15 @@
 
 <header class="page">
   <div class="wrap">
-    <span class="pill"><span class="dot"></span> AltStore source</span>
-    <h1>Install gterm with <span class="grad-text">AltStore</span></h1>
-    <p class="lead">Add gterm to <b>AltStore</b> or <b>SideStore</b> — sideload a Ghostty-powered iOS terminal that connects over SSH, without TestFlight or the App Store.</p>
+    <span class="pill"><span class="dot"></span> AltStore · SideStore source</span>
+    <h1>Sideload gterm with <span class="grad-text">AltStore or SideStore</span></h1>
+    <p class="lead">A Ghostty-powered iOS terminal that connects over SSH — installed from one shared source, signed on-device with your own Apple ID.</p>
     <div class="cta">
       <a class="btn btn-primary" href="altstore://source?url=https%3A%2F%2Fmadeye.github.io%2Fgterm%2Faltstore.json">Add to AltStore →</a>
-      <a class="btn btn-ghost"  href="sidestore://source?url=https%3A%2F%2Fmadeye.github.io%2Fgterm%2Faltstore.json">Add to SideStore</a>
+      <a class="btn btn-primary" href="sidestore://source?url=https%3A%2F%2Fmadeye.github.io%2Fgterm%2Faltstore.json">Add to SideStore →</a>
     </div>
     <div class="url-row"><span>Source URL:</span> <a href="../altstore.json">https://madeye.github.io/gterm/altstore.json</a></div>
-    <div class="copy-note">Tap the buttons on iOS with AltStore (or SideStore) installed; on desktop you can copy the source URL and add it manually in the app.</div>
+    <div class="copy-note">Both stores read the same source. Tap a button on iOS with the corresponding app installed; on desktop, copy the URL and add it under <b>Sources → +</b>.</div>
   </div>
 </header>
 
@@ -106,14 +106,21 @@
   <div class="wrap">
     <h2>Install steps</h2>
     <ol>
-      <li>Install <a href="https://altstore.io/">AltStore</a> (or <a href="https://sidestore.io/">SideStore</a>) on your iPhone.</li>
-      <li>Open the link above on the device, or in AltStore go to <b>Sources → +</b> and paste <code>https://madeye.github.io/gterm/altstore.json</code>.</li>
+      <li>Install <a href="https://altstore.io/">AltStore</a> or <a href="https://sidestore.io/">SideStore</a> on your iPhone (whichever you prefer — SideStore doesn't need a Mac companion).</li>
+      <li>Tap the matching <b>Add to …</b> button above on the device, or open the store and paste <code>https://madeye.github.io/gterm/altstore.json</code> under <b>Sources → +</b>.</li>
       <li>Find <b>gterm</b> in the source and tap <b>Free</b> to install.</li>
-      <li>AltStore re-signs the app with your Apple ID; trust the developer in <b>Settings → General → VPN &amp; Device Management</b>.</li>
+      <li>The store re-signs the app with your Apple ID; trust the developer in <b>Settings → General → VPN &amp; Device Management</b>.</li>
     </ol>
 
+    <h2>AltStore vs. SideStore</h2>
+    <ul>
+      <li><b>AltStore</b> pairs with a Mac/Windows companion (AltServer) that refreshes the signature when both are on the same Wi-Fi.</li>
+      <li><b>SideStore</b> refreshes on-device — no companion needed. It runs an embedded server and enables JIT on supported builds.</li>
+      <li>Both read this exact source, install the same <code>.ipa</code>, and sign it with your own Apple ID.</li>
+    </ul>
+
     <h2>About sideloading</h2>
-    <p>AltStore re-signs the app on install with your own Apple ID, which means it expires every 7 days on a free Apple ID (refresh in AltStore over Wi-Fi to renew) or yearly on a paid Apple Developer account. The TestFlight build is a smoother path if you prefer — <a href="https://testflight.apple.com/join/qDNYS7fd">join here</a>.</p>
+    <p>The store re-signs the app with your own Apple ID, which means it expires every 7 days on a free Apple ID (refresh in AltStore/SideStore over Wi-Fi to renew) or yearly on a paid Apple Developer account. The TestFlight build is a smoother path if you prefer — <a href="https://testflight.apple.com/join/qDNYS7fd">join here</a>.</p>
 
     <h2>Privacy</h2>
     <p>gterm collects no personal data. SSH credentials and imported keys are stored only in the on-device Keychain. AI features are off until you configure a provider; when enabled they talk directly to that provider with your own API key. See the full <a href="../privacy/">privacy policy</a>.</p>


### PR DESCRIPTION
- Cut the first GitHub release [v1.1-2026060109](https://github.com/madeye/gterm/releases/tag/v1.1-2026060109) with the unsigned `gterm-1.1-2026060109.ipa` attached.
- Updated **docs/altstore.json** with the real `downloadURL`, `size` (18,147,048), and `sha256` so AltStore/SideStore can verify and install.
- Gave **SideStore** equal billing in the landing page: heading now covers both stores, the "Add to SideStore" button is a primary CTA (matching AltStore's prominence), and a new "AltStore vs. SideStore" section explains the tradeoff (AltServer companion vs. on-device refresh).
- README updated to match.

Both stores read the same source JSON, install the same unsigned IPA, and re-sign with the user's Apple ID at install time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)