### PR TITLE
gterm: re-show software keyboard on tap after dismissal

### DIFF
--- a/Sources/Ghostty/TerminalSurfaceView+Link.swift
+++ b/Sources/Ghostty/TerminalSurfaceView+Link.swift
@@ -19,6 +19,8 @@ extension TerminalSurfaceView {
 
     @objc private func handleLinkTap(_ gesture: UITapGestureRecognizer) {
         guard gesture.state == .ended, let surface = ghosttySurface else { return }
+        // A tap is also the affordance for re-summoning a dismissed keyboard.
+        showKeyboardIfNeeded()
         let loc = gesture.location(in: self)
         let superMods = GHOSTTY_MODS_SUPER
         // Move with super so the cell registers as over_link, then click it.

--- a/Sources/Ghostty/TerminalSurfaceView.swift
+++ b/Sources/Ghostty/TerminalSurfaceView.swift
@@ -46,6 +46,20 @@ final class TerminalSurfaceView: UIView {
         let pinch = UIPinchGestureRecognizer(target: self, action: #selector(handlePinch(_:)))
         addGestureRecognizer(pinch)
 
+        // Track software-keyboard visibility so a tap can re-summon a keyboard
+        // dismissed with the iPadOS hide key (which hides the keyboard without
+        // necessarily resigning first responder). Selector-based observers are
+        // auto-removed on dealloc.
+        let nc = NotificationCenter.default
+        nc.addObserver(
+            self, selector: #selector(keyboardDidShow),
+            name: UIResponder.keyboardDidShowNotification, object: nil
+        )
+        nc.addObserver(
+            self, selector: #selector(keyboardWillHide),
+            name: UIResponder.keyboardWillHideNotification, object: nil
+        )
+
         guard let app = ghostty.app else {
             Ghostty.logger.error("TerminalSurfaceView created without a ghostty app")
             return
@@ -179,6 +193,27 @@ final class TerminalSurfaceView: UIView {
         let ok = super.resignFirstResponder()
         if let surface { ghostty_surface_set_focus(surface, false) }
         return ok
+    }
+
+    /// Whether the software keyboard (or the accessory bar when a hardware
+    /// keyboard is attached) is currently on screen.
+    private var keyboardVisible = false
+
+    @objc private func keyboardDidShow() { keyboardVisible = true }
+    @objc private func keyboardWillHide() { keyboardVisible = false }
+
+    /// Bring the software keyboard back if the user dismissed it (e.g. with the
+    /// iPadOS keyboard hide key). Tapping the terminal is the only affordance
+    /// for getting it back, so the single-tap gesture calls this.
+    func showKeyboardIfNeeded() {
+        if !isFirstResponder {
+            _ = becomeFirstResponder()
+        } else if !keyboardVisible {
+            // Still first responder but the keyboard is hidden: cycle the
+            // responder to force the keyboard back up.
+            _ = resignFirstResponder()
+            _ = becomeFirstResponder()
+        }
     }
 
     // MARK: Font size (pinch-to-zoom)


### PR DESCRIPTION
## Summary

Fixes #28 — on iPadOS, hiding the software keyboard with the keyboard dismiss key left no way to bring it back in an active session.

Root cause: `TerminalSurfaceView` acquires first responder only once, in `didMoveToWindow`, and the single-tap gesture only performed link detection — nothing ever re-summoned the keyboard.

## Changes

- Track software-keyboard visibility in `TerminalSurfaceView` via `keyboardDidShow`/`keyboardWillHide` notifications.
- New `showKeyboardIfNeeded()`: re-acquires first responder if it was lost, or cycles the responder (resign → become) when we still hold it but the keyboard is hidden — the iPadOS hide key can dismiss the keyboard without resigning the responder, in which case a plain `becomeFirstResponder()` is a no-op.
- The single-tap gesture calls it before link handling, so tapping the terminal is the affordance for getting the keyboard back.

## Testing

- `gtermTests` pass; simulator build succeeds.
- Manual QA (needs a device/simulator with the software keyboard): SSH in, run a full-screen TUI, hide the keyboard with the iPadOS dismiss key, tap the terminal → keyboard should return. Also verify a tap on a URL still opens the in-app browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)