### PR TITLE
gterm: replace TestFlight links with App Store link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 An iOS terminal app that renders with [ghostty](../ghostty)'s `libghostty`
 engine (GPU/Metal, full xterm/VT emulation) and connects over **SSH**.
 
-> 📲 **Try the beta:** [Join on TestFlight](https://testflight.apple.com/join/qDNYS7fd) (iOS 17+, requires Apple's TestFlight app).
+> 📲 **Get the app:** [Download on the App Store](https://apps.apple.com/us/app/gterm-ghostty-ssh/id6774837597) (iOS 17+).
 > Or sideload with [**AltStore** or **SideStore**](https://madeye.github.io/gterm/altstore/) — both read the same source URL `https://madeye.github.io/gterm/altstore.json`.
 
 iOS can't `fork`/`exec` a local shell, so gterm drives the terminal from an SSH

--- a/docs/altstore/index.html
+++ b/docs/altstore/index.html
@@ -120,7 +120,7 @@
     </ul>
 
     <h2>About sideloading</h2>
-    <p>The store re-signs the app with your own Apple ID, which means it expires every 7 days on a free Apple ID (refresh in AltStore/SideStore over Wi-Fi to renew) or yearly on a paid Apple Developer account. The TestFlight build is a smoother path if you prefer — <a href="https://testflight.apple.com/join/qDNYS7fd">join here</a>.</p>
+    <p>The store re-signs the app with your own Apple ID, which means it expires every 7 days on a free Apple ID (refresh in AltStore/SideStore over Wi-Fi to renew) or yearly on a paid Apple Developer account. The App Store build is a smoother path if you prefer — <a href="https://apps.apple.com/us/app/gterm-ghostty-ssh/id6774837597">get it here</a>.</p>
 
     <h2>Privacy</h2>
     <p>gterm collects no personal data. SSH credentials and imported keys are stored only in the on-device Keychain. AI features are off until you configure a provider; when enabled they talk directly to that provider with your own API key. See the full <a href="../privacy/">privacy policy</a>.</p>
@@ -132,7 +132,7 @@
     <a class="brand" href="../"><img src="../assets/icon.png" alt="" /> gterm</a>
     <div class="foot-links">
       <a href="../">Home</a>
-      <a href="https://testflight.apple.com/join/qDNYS7fd">TestFlight</a>
+      <a href="https://apps.apple.com/us/app/gterm-ghostty-ssh/id6774837597">App Store</a>
       <a href="https://github.com/madeye/gterm">GitHub</a>
       <a href="../privacy/">Privacy</a>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -167,9 +167,9 @@
       <a href="#shots">Screens</a>
       <a href="https://github.com/madeye/gterm">GitHub</a>
     </div>
-    <a class="btn btn-primary" href="https://testflight.apple.com/join/qDNYS7fd">
+    <a class="btn btn-primary" href="https://apps.apple.com/us/app/gterm-ghostty-ssh/id6774837597">
       <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M2.4 11.4 21.5 2.5 12.6 21.6l-2.8-8-7-2.2Z"/></svg>
-      TestFlight
+      App Store
     </a>
   </div>
 </nav>
@@ -181,10 +181,10 @@
     <h1>A real terminal<br/>in your pocket,<br/><span class="grad-text">over SSH.</span></h1>
     <p class="lead"><b>gterm</b> renders with Ghostty's GPU engine for true xterm/VT emulation, connects straight to your servers over SSH, keeps your keys on-device, and ships an <b>AI command assistant</b> that writes the commands for you.</p>
     <div class="cta-row">
-      <a class="btn btn-primary" href="https://testflight.apple.com/join/qDNYS7fd">Join the TestFlight beta →</a>
+      <a class="btn btn-primary" href="https://apps.apple.com/us/app/gterm-ghostty-ssh/id6774837597">Download on the App Store →</a>
       <a class="btn btn-ghost" href="https://github.com/madeye/gterm">View on GitHub</a>
     </div>
-    <div class="cta-note"><span class="dot" style="background:var(--violet);box-shadow:0 0 10px var(--violet-bright)"></span> Free public beta · needs Apple's TestFlight app · iOS 17+</div>
+    <div class="cta-note"><span class="dot" style="background:var(--violet);box-shadow:0 0 10px var(--violet-bright)"></span> Free on the App Store · iOS 17+</div>
   </div>
 
   <div class="term" aria-hidden="true">
@@ -283,7 +283,7 @@ README.md&nbsp;&nbsp;app.py&nbsp;&nbsp;package.json&nbsp;&nbsp;<span class="pth"
   <div class="wrap">
     <a class="brand" href="#top"><img src="assets/icon.png" alt="" /> gterm</a>
     <div class="foot-links">
-      <a href="https://testflight.apple.com/join/qDNYS7fd">TestFlight beta</a>
+      <a href="https://apps.apple.com/us/app/gterm-ghostty-ssh/id6774837597">App Store</a>
       <a href="altstore/">AltStore</a>
       <a href="https://github.com/madeye/gterm">GitHub</a>
       <a href="https://github.com/madeye/gterm/blob/main/PLAN.md">Architecture</a>


### PR DESCRIPTION
gterm is now live on the App Store, so point README and the docs site (landing page + AltStore page) at https://apps.apple.com/us/app/gterm-ghostty-ssh/id6774837597 instead of the TestFlight beta invite, and update the surrounding beta copy accordingly.

Docs/HTML-only change — no source code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)