### PR TITLE
gterm: refine landing page for mobile devices

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 <title>gterm — a real terminal on iOS, over SSH</title>
 <meta name="description" content="gterm is an iOS terminal that renders with Ghostty's GPU engine, connects over SSH, manages your keys in the Secure Enclave, and ships an AI command assistant." />
 <meta name="theme-color" content="#0a0b0f" />
@@ -72,7 +72,7 @@
   .btn-ghost:hover{border-color:var(--cyan);color:#fff}
 
   /* hero */
-  .hero{padding:92px 0 40px;display:grid;grid-template-columns:1.05fr .95fr;gap:54px;align-items:center}
+  .hero{padding:92px 28px 40px;display:grid;grid-template-columns:1.05fr .95fr;gap:54px;align-items:center}
   .hero h1{font-size:62px;line-height:1.04;font-weight:800;letter-spacing:-.03em;margin:22px 0 18px}
   .hero p.lead{font-size:19px;color:var(--muted);max-width:520px;margin-bottom:30px}
   .hero p.lead b{color:var(--text);font-weight:600}
@@ -141,18 +141,46 @@
   footer{border-top:1px solid var(--border);padding:46px 0 60px;margin-top:30px}
   footer .wrap{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:18px}
   footer .brand img{width:30px;height:30px}
-  .foot-links{display:flex;gap:24px;font-size:14px;color:var(--muted)}
+  .foot-links{display:flex;flex-wrap:wrap;gap:12px 24px;font-size:14px;color:var(--muted)}
   .foot-links a:hover{color:var(--text)}
   .copy{font-size:13px;color:var(--faint)}
 
   @media (max-width:920px){
     .hero{grid-template-columns:1fr;gap:40px;padding-top:64px}
-    .hero h1{font-size:46px}
+    .hero h1{font-size:clamp(34px,10.5vw,46px)}
+    .sec-head h2{font-size:clamp(28px,8vw,34px)}
+    .band h2{font-size:clamp(24px,7vw,30px)}
     .feat-grid,.shots{grid-template-columns:1fr}
-    .band{grid-template-columns:1fr;text-align:center}
-    .band p{margin:0 auto}.band .stats{justify-content:center}.band-art{order:-1}
+    .band{grid-template-columns:1fr;text-align:center;padding:38px 26px}
+    .band p{margin:0 auto}
+    .band .stats{justify-content:center;flex-wrap:wrap;gap:22px}
+    .band-art{order:-1}
     .nav-links{display:none}
     .shots{gap:54px}
+  }
+
+  @media (max-width:520px){
+    .wrap{padding:0 max(20px,env(safe-area-inset-right)) 0 max(20px,env(safe-area-inset-left))}
+    body::before,body::after{width:420px;height:420px;filter:blur(90px);opacity:.4}
+    nav .wrap{height:60px}
+    nav .btn{padding:9px 14px;font-size:13.5px}
+    .brand{font-size:17px}
+    .hero{padding:52px max(20px,env(safe-area-inset-right)) 28px max(20px,env(safe-area-inset-left));gap:32px}
+    .hero p.lead{font-size:16.5px;margin-bottom:24px}
+    .cta-row{flex-direction:column;align-items:stretch}
+    .cta-row .btn{justify-content:center;padding:14px 20px}
+    section{padding:52px 0}
+    .sec-head{margin-bottom:36px}
+    .sec-head p{font-size:15.5px}
+    .card{padding:22px}
+    .term{border-radius:14px}
+    .term-body{padding:16px 14px 18px;font-size:12.5px}
+    .ai-sug{flex-wrap:wrap;padding:10px 12px;gap:8px}
+    .ai-sug code{font-size:12px;white-space:normal;word-break:break-word}
+    .band .stats .s b{font-size:22px}
+    .phone{width:min(248px,78vw)}
+    footer .wrap{flex-direction:column;align-items:flex-start;gap:20px}
+    footer{padding:38px 0 max(44px,env(safe-area-inset-bottom))}
   }
 </style>
 </head>


### PR DESCRIPTION
## Summary
- Fix a real mobile bug: `.hero`'s `padding:92px 0 40px` shorthand overrode `.wrap`'s horizontal padding, so hero content sat flush against the screen edge on phones
- Add a dedicated `≤520px` breakpoint: full-width stacked CTAs, tighter nav/section/card spacing, smaller terminal-mock type, wrapping AI-suggestion pill, stacked footer with wrapping link row
- Fluid `clamp()` headline sizes at the existing 920px breakpoint (h1, section heads, band)
- `viewport-fit=cover` + `env(safe-area-inset-*)` padding for notched iPhones
- Smaller/lighter ambient glow blobs on small screens (less GPU blur cost)

## Verification
Served `docs/` locally and rendered in Chrome inside an iframe harness at **375×812** (iPhone SE/mini) and **430×932** (iPhone Pro Max): scrolled every section — no horizontal overflow (`scrollWidth == innerWidth`), no clipped terminal-mock content, cards/band/shots/footer all lay out cleanly. Docs-only change; app CI is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)