### PR TITLE
gterm: keep SSH sessions alive when returning to the main UI

### DIFF
--- a/Sources/Terminal/ActiveSession.swift
+++ b/Sources/Terminal/ActiveSession.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+
+/// A live terminal session — the `SSHSession` transport plus the ghostty
+/// `TerminalSurfaceView` it renders into — owned independently of any screen.
+/// Because both halves are retained here, dismissing the terminal UI leaves
+/// the SSH connection running and the scrollback intact; reopening the host
+/// reattaches the same surface.
+final class ActiveSession: ObservableObject, Identifiable {
+    /// Keyed by the saved host so a host has at most one live session.
+    let id: UUID
+    let connection: SSHConnection
+    let surface: TerminalSurfaceView
+    private(set) var ssh: SSHSession!
+
+    @Published private(set) var state: SSHSessionState = .idle
+    @Published var forwardStates: [UUID: PortForwardStatus] = [:]
+    /// A pending host-key trust decision, surfaced by whichever screen is
+    /// currently showing this session.
+    @Published var hostKeyRequest: HostKeyPromptRequest?
+
+    init(connection: SSHConnection, ghostty: Ghostty.App, forwards: [PortForward]) {
+        self.id = connection.savedID ?? connection.id
+        self.connection = connection
+        let surface = TerminalSurfaceView(ghostty: ghostty)
+        self.surface = surface
+        let session = SSHSession(
+            connection: connection,
+            view: surface,
+            forwards: forwards,
+            onHostKeyPrompt: { [weak self] prompt, decide in
+                DispatchQueue.main.async {
+                    self?.hostKeyRequest = HostKeyPromptRequest(prompt: prompt, decide: decide)
+                }
+            },
+            onForwardChange: { [weak self] id, status in
+                DispatchQueue.main.async { self?.forwardStates[id] = status }
+            }
+        ) { [weak self] newState in
+            self?.state = newState
+        }
+        self.ssh = session
+        surface.delegate = session
+    }
+
+    /// Whether the transport is (or may still become) usable. Failed and
+    /// closed sessions are dead: they are pruned rather than kept around.
+    var isAlive: Bool {
+        switch state {
+        case .failed, .closed: return false
+        case .idle, .connecting, .authenticating, .connected: return true
+        }
+    }
+
+    func start() {
+        ssh.start()
+    }
+
+    /// Tear down the transport. `SSHSession.stop()` closes channels without a
+    /// state callback, so mark the session closed here.
+    func stop() {
+        ssh.stop()
+        state = .closed
+    }
+}
+
+/// Owns every `ActiveSession`, keeping connections alive while the user is
+/// back in the main UI. The Hosts list uses it to show live status, reattach,
+/// and disconnect.
+final class SessionManager: ObservableObject {
+    @Published private(set) var sessions: [ActiveSession] = []
+
+    func session(for id: UUID) -> ActiveSession? {
+        sessions.first { $0.id == id }
+    }
+
+    /// Reattach to the live session for this connection, or start a new one.
+    /// A dead leftover (failed / closed while backgrounded) is replaced.
+    func open(
+        _ connection: SSHConnection,
+        ghostty: Ghostty.App,
+        forwards: [PortForward]
+    ) -> ActiveSession {
+        let key = connection.savedID ?? connection.id
+        if let existing = session(for: key) {
+            if existing.isAlive { return existing }
+            remove(existing)
+        }
+        let session = ActiveSession(connection: connection, ghostty: ghostty, forwards: forwards)
+        sessions.append(session)
+        session.start()
+        return session
+    }
+
+    func disconnect(_ session: ActiveSession) {
+        session.stop()
+        remove(session)
+    }
+
+    /// Called when the terminal screen is dismissed: live sessions keep
+    /// running in the background, dead ones are dropped so the next tap on
+    /// the host reconnects fresh.
+    func pruneIfDead(_ session: ActiveSession) {
+        if !session.isAlive { remove(session) }
+    }
+
+    private func remove(_ session: ActiveSession) {
+        sessions.removeAll { $0.id == session.id }
+    }
+}

--- a/Sources/UI/ConnectionListView.swift
+++ b/Sources/UI/ConnectionListView.swift
@@ -2,11 +2,14 @@ import SwiftUI
 
 /// The "Hosts" tab: saved SSH connections. Tap to connect (resolving selected
 /// keys and any saved password; prompting for a password only if there's no
-/// key and none saved). Swipe to edit/delete, "+" to add.
+/// key and none saved). A host with a live background session shows a status
+/// dot; tapping it reattaches, and a leading swipe disconnects. Swipe to
+/// edit/delete, "+" to add.
 struct ConnectionListView: View {
     @ObservedObject var store: ConnectionStore
     @ObservedObject var keyStore: KeyStore
     @ObservedObject var forwardStore: PortForwardStore
+    @ObservedObject var sessions: SessionManager
     let onConnect: (SSHConnection) -> Void
 
     @State private var editing: SavedConnection?
@@ -25,9 +28,22 @@ struct ConnectionListView: View {
                 }
                 ForEach(store.connections) { conn in
                     Button { connect(conn) } label: {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(conn.title).font(.headline)
-                            Text(conn.subtitle).font(.subheadline).foregroundStyle(.secondary)
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(conn.title).font(.headline)
+                                Text(conn.subtitle).font(.subheadline).foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            if let session = sessions.session(for: conn.id) {
+                                SessionBadge(session: session)
+                            }
+                        }
+                    }
+                    .swipeActions(edge: .leading) {
+                        if let session = sessions.session(for: conn.id) {
+                            Button { sessions.disconnect(session) } label: {
+                                Label("Disconnect", systemImage: "bolt.slash")
+                            }.tint(.orange)
                         }
                     }
                     .swipeActions(edge: .trailing) {
@@ -85,6 +101,12 @@ struct ConnectionListView: View {
     }
 
     private func connect(_ conn: SavedConnection) {
+        // A live background session just gets reattached — no credentials
+        // needed, so skip any password prompt.
+        if let session = sessions.session(for: conn.id), session.isAlive {
+            onConnect(session.connection)
+            return
+        }
         let keys = keyTexts(for: conn)
         if let saved = store.savedPassword(for: conn) {
             onConnect(makeConnection(conn, password: saved))
@@ -93,6 +115,35 @@ struct ConnectionListView: View {
         } else {
             promptPassword = ""
             passwordPromptFor = conn
+        }
+    }
+}
+
+/// Live status dot for a host with a background session: green when
+/// connected, orange while connecting, gray once the session has died.
+private struct SessionBadge: View {
+    @ObservedObject var session: ActiveSession
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Circle().fill(color).frame(width: 8, height: 8)
+            Text(text).font(.caption).foregroundStyle(.secondary)
+        }
+    }
+
+    private var color: Color {
+        switch session.state {
+        case .connected: return .green
+        case .idle, .connecting, .authenticating: return .orange
+        case .failed, .closed: return .gray
+        }
+    }
+
+    private var text: String {
+        switch session.state {
+        case .connected: return "active"
+        case .idle, .connecting, .authenticating: return "connecting"
+        case .failed, .closed: return "ended"
         }
     }
 }

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -5,7 +5,8 @@ struct RootView: View {
     @StateObject private var connections = ConnectionStore()
     @StateObject private var keys = KeyStore()
     @StateObject private var forwards = PortForwardStore()
-    @State private var activeConnection: SSHConnection?
+    @StateObject private var sessions = SessionManager()
+    @State private var activeSession: ActiveSession?
 
     /// Whether the user has seen the Get Started screen (persisted).
     @AppStorage("hasSeenWelcome") private var hasSeenWelcome = false
@@ -13,8 +14,11 @@ struct RootView: View {
 
     var body: some View {
         TabView {
-            ConnectionListView(store: connections, keyStore: keys, forwardStore: forwards) { connection in
-                activeConnection = connection
+            ConnectionListView(
+                store: connections, keyStore: keys, forwardStore: forwards, sessions: sessions
+            ) { connection in
+                let connectionForwards = connection.savedID.map { forwards.forwards(for: $0) } ?? []
+                activeSession = sessions.open(connection, ghostty: ghostty, forwards: connectionForwards)
             }
             .tabItem { Label("Hosts", systemImage: "server.rack") }
 
@@ -27,13 +31,12 @@ struct RootView: View {
             SettingsView(showWelcome: $showWelcome)
                 .tabItem { Label("Settings", systemImage: "gearshape") }
         }
-        .fullScreenCover(item: $activeConnection) { connection in
-            TerminalScreen(
-                connection: connection,
-                savedConnectionID: connection.savedID,
-                forwardStore: forwards
-            ) {
-                activeConnection = nil
+        .fullScreenCover(item: $activeSession) { session in
+            TerminalScreen(session: session, forwardStore: forwards) {
+                // Detach only: a live session keeps running in the background
+                // so the user can come back to it from the Hosts list.
+                sessions.pruneIfDead(session)
+                activeSession = nil
             }
             .environmentObject(ghostty)
         }

--- a/Sources/UI/TerminalScreen.swift
+++ b/Sources/UI/TerminalScreen.swift
@@ -14,68 +14,49 @@ struct TappedURL: Identifiable {
 }
 
 /// Full-screen terminal for an active SSH connection, with a slim status bar
-/// and a close button.
+/// and a close button. The session itself is owned by `SessionManager`, so
+/// leaving this screen detaches from — but does not disconnect — the session.
 struct TerminalScreen: View {
-    @EnvironmentObject private var ghostty: Ghostty.App
-    let connection: SSHConnection
-    /// The owning `SavedConnection.id`, used to resolve persisted port forwards.
-    let savedConnectionID: UUID?
+    @ObservedObject var session: ActiveSession
     @ObservedObject var forwardStore: PortForwardStore
     let onClose: () -> Void
 
-    @State private var state: SSHSessionState = .idle
-    @State private var hostKeyRequest: HostKeyPromptRequest?
-    @State private var terminalView: TerminalSurfaceView?
     @State private var showingAICommands = false
     @State private var showingForwards = false
-    @State private var forwardStates: [UUID: PortForwardStatus] = [:]
-    @State private var session: SSHSession?
     @State private var browsing: PortForward?
     /// A URL tapped in the terminal, opened in the in-app browser.
     @State private var linkURL: TappedURL?
 
+    private var connection: SSHConnection { session.connection }
+
     /// Persisted forward configs for this connection (empty if not a saved host).
     private var connectionForwards: [PortForward] {
-        guard let id = savedConnectionID else { return [] }
+        guard let id = connection.savedID else { return [] }
         return forwardStore.forwards(for: id)
     }
 
     var body: some View {
         VStack(spacing: 0) {
             statusBar
-            TerminalView(ghostty: ghostty, makeSession: { view in
-                SSHSession(
-                    connection: connection,
-                    view: view,
-                    forwards: connectionForwards,
-                    onHostKeyPrompt: { prompt, decide in
-                        hostKeyRequest = HostKeyPromptRequest(prompt: prompt, decide: decide)
-                    },
-                    onForwardChange: { id, st in forwardStates[id] = st }
-                ) { newState in
-                    state = newState
-                }
-            }, onCreate: { view in
-                view.onOpenURL = { url in linkURL = TappedURL(url: url) }
-                DispatchQueue.main.async { terminalView = view }
-            }, onSession: { s in
-                DispatchQueue.main.async { session = s }
-            })
+            TerminalView(surface: session.surface)
+        }
+        .onAppear {
+            session.surface.onOpenURL = { url in linkURL = TappedURL(url: url) }
         }
         .sheet(isPresented: $showingAICommands) {
             AICommandSheet(
-                runCommand: { terminalView?.runCommand($0) },
+                runCommand: { session.surface.runCommand($0) },
                 gatherContext: {
-                    (terminalView?.readVisibleText() ?? "", CommandHistory.shared.recent(limit: 15))
+                    (session.surface.readVisibleText(), CommandHistory.shared.recent(limit: 15))
                 }
             )
         }
         .sheet(isPresented: $showingForwards) {
             PortForwardStatusSheet(
                 forwards: connectionForwards,
-                statuses: forwardStates,
+                statuses: session.forwardStates,
                 onToggle: { f, on in
-                    if on { session?.startForward(f.id) } else { session?.stopForward(f.id) }
+                    if on { session.ssh.startForward(f.id) } else { session.ssh.stopForward(f.id) }
                 },
                 onOpenBrowser: { f in
                     showingForwards = false
@@ -94,21 +75,21 @@ struct TerminalScreen: View {
         .background(Color.black.ignoresSafeArea())
         .preferredColorScheme(.dark)
         .alert(
-            hostKeyRequest?.prompt.kind == .changed ? "Host Key Changed" : "Unknown Host",
+            session.hostKeyRequest?.prompt.kind == .changed ? "Host Key Changed" : "Unknown Host",
             isPresented: Binding(
-                get: { hostKeyRequest != nil },
-                set: { if !$0 { hostKeyRequest?.decide(false); hostKeyRequest = nil } }
+                get: { session.hostKeyRequest != nil },
+                set: { if !$0 { session.hostKeyRequest?.decide(false); session.hostKeyRequest = nil } }
             ),
-            presenting: hostKeyRequest
+            presenting: session.hostKeyRequest
         ) { request in
             let isChanged = request.prompt.kind == .changed
             Button(isChanged ? "Accept New Key" : "Trust", role: isChanged ? .destructive : nil) {
                 request.decide(true)
-                hostKeyRequest = nil
+                session.hostKeyRequest = nil
             }
             Button("Cancel", role: .cancel) {
                 request.decide(false)
-                hostKeyRequest = nil
+                session.hostKeyRequest = nil
             }
         } message: { request in
             Text(hostKeyMessage(request.prompt))
@@ -160,7 +141,7 @@ struct TerminalScreen: View {
                 Image(systemName: "network").font(.body.weight(.semibold))
             }
             .accessibilityLabel("Port forwards")
-            .disabled(state != .connected)
+            .disabled(session.state != .connected)
             statusIndicator
         }
         .padding(.horizontal, 14)
@@ -170,7 +151,7 @@ struct TerminalScreen: View {
     }
 
     @ViewBuilder private var statusIndicator: some View {
-        switch state {
+        switch session.state {
         case .idle, .connecting, .authenticating:
             HStack(spacing: 6) {
                 ProgressView().controlSize(.small).tint(.white)
@@ -189,7 +170,7 @@ struct TerminalScreen: View {
     }
 
     private var label: String {
-        switch state {
+        switch session.state {
         case .connecting: return "connecting…"
         case .authenticating: return "authenticating…"
         default: return ""

--- a/Sources/UI/TerminalView.swift
+++ b/Sources/UI/TerminalView.swift
@@ -1,38 +1,15 @@
 import SwiftUI
 
-/// SwiftUI wrapper that hosts a `TerminalSurfaceView` and binds it to a terminal
-/// session produced by `makeSession` (loopback, SSH, ...). The session is the
-/// surface's delegate and is retained for the view's lifetime.
+/// SwiftUI wrapper that hosts a `TerminalSurfaceView` owned by an
+/// `ActiveSession`. The session and surface outlive this view: dismissing the
+/// screen detaches the surface but leaves the SSH connection running, and
+/// presenting it again reattaches the same surface with its scrollback.
 struct TerminalView: UIViewRepresentable {
-    let ghostty: Ghostty.App
-    let makeSession: (TerminalSurfaceView) -> TerminalSession
-    /// Called once with the created surface view so the hosting screen can drive
-    /// it (e.g. the AI command assistant typing a command into the terminal).
-    var onCreate: ((TerminalSurfaceView) -> Void)? = nil
-    /// Called in `makeUIView` with the freshly made session, when it is an
-    /// `SSHSession`, so the hosting screen can drive port forwards.
-    var onSession: ((SSHSession) -> Void)? = nil
+    let surface: TerminalSurfaceView
 
     func makeUIView(context: Context) -> TerminalSurfaceView {
-        let view = TerminalSurfaceView(ghostty: ghostty)
-        let session = makeSession(view)
-        view.delegate = session
-        context.coordinator.session = session
-        session.start()
-        if let ssh = session as? SSHSession { onSession?(ssh) }
-        onCreate?(view)
-        return view
+        surface
     }
 
     func updateUIView(_ uiView: TerminalSurfaceView, context: Context) {}
-
-    static func dismantleUIView(_ uiView: TerminalSurfaceView, coordinator: Coordinator) {
-        coordinator.session?.stop()
-    }
-
-    func makeCoordinator() -> Coordinator { Coordinator() }
-
-    final class Coordinator {
-        var session: TerminalSession?
-    }
 }


### PR DESCRIPTION
## Summary
- Sessions are now owned by a `SessionManager` instead of the terminal screen: the back button only detaches the UI, leaving the SSH connection and scrollback running in the background.
- New `ActiveSession` keeps the `SSHSession` + ghostty `TerminalSurfaceView` pair alive; reopening the host reattaches the same surface without re-prompting for credentials.
- Hosts list shows a live status badge (active / connecting / ended) and a leading-swipe Disconnect action.
- Dead sessions (failed / shell exited) are pruned on dismissal so the next tap reconnects fresh.

## Testing
- `xcodebuild -scheme gterm -sdk iphonesimulator` — BUILD SUCCEEDED
- `xcodebuild -scheme gtermTests test` on iPhone Air simulator — TEST SUCCEEDED