### PR TITLE
gterm: dismiss the terminal when the remote closes the session

### DIFF
--- a/Sources/Ghostty/AccessoryKeyboardView.swift
+++ b/Sources/Ghostty/AccessoryKeyboardView.swift
@@ -152,7 +152,37 @@ final class AccessoryKeyboardView: UIInputView {
 
     // MARK: Keys row
 
+    /// The scrollable key bar plus a fixed collapse button at the trailing
+    /// edge, so "hide keyboard" is always reachable regardless of scroll
+    /// position.
     private func buildKeysRow() -> UIView {
+        let row = UIStackView()
+        row.axis = .horizontal
+        row.spacing = 2
+        row.alignment = .center
+        row.translatesAutoresizingMaskIntoConstraints = false
+        row.isLayoutMarginsRelativeArrangement = true
+        row.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 6)
+        row.addArrangedSubview(buildKeysScroll())
+        row.addArrangedSubview(buildHideButton())
+        return row
+    }
+
+    private func buildHideButton() -> UIButton {
+        let button = UIButton(type: .system)
+        var config = UIButton.Configuration.plain()
+        config.image = UIImage(systemName: "keyboard.chevron.compact.down")
+        config.baseForegroundColor = .label
+        config.contentInsets = NSDirectionalEdgeInsets(top: 6, leading: 8, bottom: 6, trailing: 8)
+        button.configuration = config
+        button.accessibilityLabel = "Hide keyboard"
+        button.addAction(UIAction { [weak self] _ in
+            self?.target?.collapseKeyboard()
+        }, for: .touchUpInside)
+        return button
+    }
+
+    private func buildKeysScroll() -> UIView {
         let scroll = UIScrollView()
         scroll.translatesAutoresizingMaskIntoConstraints = false
         scroll.showsHorizontalScrollIndicator = false

--- a/Sources/Ghostty/TerminalSurfaceView.swift
+++ b/Sources/Ghostty/TerminalSurfaceView.swift
@@ -203,8 +203,8 @@ final class TerminalSurfaceView: UIView {
     @objc private func keyboardWillHide() { keyboardVisible = false }
 
     /// Bring the software keyboard back if the user dismissed it (e.g. with the
-    /// iPadOS keyboard hide key). Tapping the terminal is the only affordance
-    /// for getting it back, so the single-tap gesture calls this.
+    /// iPadOS keyboard hide key, or the accessory bar's collapse button). The
+    /// single-tap gesture calls this so tapping the terminal expands it again.
     func showKeyboardIfNeeded() {
         if !isFirstResponder {
             _ = becomeFirstResponder()
@@ -213,6 +213,22 @@ final class TerminalSurfaceView: UIView {
             // responder to force the keyboard back up.
             _ = resignFirstResponder()
             _ = becomeFirstResponder()
+        }
+    }
+
+    /// Collapse the on-screen keyboard (and the accessory bar with it), giving
+    /// the whole screen to the terminal. Tapping the terminal or the status-bar
+    /// keyboard button expands it again.
+    func collapseKeyboard() {
+        _ = resignFirstResponder()
+    }
+
+    /// Toggle the on-screen keyboard: collapse when visible, expand otherwise.
+    func toggleKeyboard() {
+        if isFirstResponder && keyboardVisible {
+            collapseKeyboard()
+        } else {
+            showKeyboardIfNeeded()
         }
     }
 

--- a/Sources/UI/TerminalScreen.swift
+++ b/Sources/UI/TerminalScreen.swift
@@ -133,6 +133,10 @@ struct TerminalScreen: View {
                 .font(.subheadline.weight(.medium))
                 .lineLimit(1)
             Spacer()
+            Button { terminalView?.toggleKeyboard() } label: {
+                Image(systemName: "keyboard").font(.body.weight(.semibold))
+            }
+            .accessibilityLabel("Toggle keyboard")
             Button { showingAICommands = true } label: {
                 Image(systemName: "sparkles").font(.body.weight(.semibold))
             }

--- a/Sources/UI/TerminalScreen.swift
+++ b/Sources/UI/TerminalScreen.swift
@@ -74,6 +74,11 @@ struct TerminalScreen: View {
         }
         .background(Color.black.ignoresSafeArea())
         .preferredColorScheme(.dark)
+        .onChange(of: state) { _, newState in
+            // A clean remote close (e.g. `exit` in the shell) dismisses the
+            // terminal; failures keep the screen up so the error stays readable.
+            if newState == .closed { onClose() }
+        }
         .alert(
             session.hostKeyRequest?.prompt.kind == .changed ? "Host Key Changed" : "Unknown Host",
             isPresented: Binding(

--- a/Sources/UI/TerminalScreen.swift
+++ b/Sources/UI/TerminalScreen.swift
@@ -74,7 +74,7 @@ struct TerminalScreen: View {
         }
         .background(Color.black.ignoresSafeArea())
         .preferredColorScheme(.dark)
-        .onChange(of: state) { _, newState in
+        .onChange(of: session.state) { _, newState in
             // A clean remote close (e.g. `exit` in the shell) dismisses the
             // terminal; failures keep the screen up so the error stays readable.
             if newState == .closed { onClose() }
@@ -138,7 +138,7 @@ struct TerminalScreen: View {
                 .font(.subheadline.weight(.medium))
                 .lineLimit(1)
             Spacer()
-            Button { terminalView?.toggleKeyboard() } label: {
+            Button { session.surface.toggleKeyboard() } label: {
                 Image(systemName: "keyboard").font(.body.weight(.semibold))
             }
             .accessibilityLabel("Toggle keyboard")


### PR DESCRIPTION
## Summary
- When the remote shell exits cleanly (e.g. typing `exit`), the terminal screen now dismisses instead of leaving a dead surface up. Failures still keep the screen visible so the error stays readable.
- Works with background sessions: `onClose` prunes the dead `ActiveSession` and returns to the Hosts list.
- Accessory bar has a fixed hide-keyboard button (always reachable regardless of scroll), and the status bar has a keyboard toggle. Collapsing resigns first responder; tapping the terminal or the status-bar button expands it again.

## Testing
- `xcodebuild -scheme gtermTests -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17' test` — TEST SUCCEEDED (45 tests)
- `xcodebuild -scheme gterm -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build` — BUILD SUCCEEDED