### PR TITLE
gterm: bump version to 1.3, build 20260907

### DIFF
--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,4 +1,5 @@
-Bug-fix release.
-
-- Fix a terminal engine overflow when resizing the terminal
-- Fix the on-screen keyboard not reappearing when you tap the terminal after dismissing it
+- New "Attach with Herdr" option per connection: launches or attaches to a Herdr session on the remote host, with taps delivered as mouse clicks and pinch-to-zoom for panes
+- SSH sessions stay alive when you return to the connection list
+- The terminal closes automatically when the remote session ends
+- Collapse and expand the on-screen keyboard
+- Fixes for SSH, AI completion, and saved-connection persistence

--- a/project.yml
+++ b/project.yml
@@ -27,10 +27,10 @@ packages:
 
 settings:
   base:
-    MARKETING_VERSION: "1.2"
+    MARKETING_VERSION: "1.3"
     # Build number is the build date (YYYYMMDD); pass CURRENT_PROJECT_VERSION
     # explicitly per build (e.g. `CURRENT_PROJECT_VERSION=$(date +%Y%m%d)`).
-    CURRENT_PROJECT_VERSION: "20260711"
+    CURRENT_PROJECT_VERSION: "20260907"
     # Team id is not committed — XcodeGen expands it from the environment.
     # Copy env.example to .env, then: set -a; source .env; set +a; xcodegen generate
     DEVELOPMENT_TEAM: ${DEVELOPMENT_TEAM}


### PR DESCRIPTION
Version bump for the 1.3 TestFlight/App Store release, plus release notes covering Herdr auto-attach, background session keepalive, close-on-remote-exit, keyboard collapse, and the audit fixes.

https://claude.ai/code/session_01DZZu4krm76hCsDfspY6rBE